### PR TITLE
Support for FooterText

### DIFF
--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -285,45 +285,21 @@ CGRect IASKCGRectSwap(CGRect rect);
     return [self.settingsReader titleForSection:section];
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section {
-    if (!_showCreditsFooter || section != [self.settingsReader numberOfSections]-1) return nil;
-    
-    // Show the credits only in the last section's footer
-    UILabel *credits = [[[UILabel alloc] initWithFrame:CGRectMake(0, 0, kIASKCreditsViewWidth, 0)] autorelease];
-    [credits setOpaque:NO];
-    [credits setNumberOfLines:0];
-    [credits setFont:[UIFont systemFontOfSize:14.0f]];
-    [credits setTextAlignment:UITextAlignmentRight];
-    [credits setTextColor:[UIColor colorWithRed:77.0f/255.0f green:87.0f/255.0f blue:107.0f/255.0f alpha:1.0f]];
-    [credits setShadowColor:[UIColor whiteColor]];
-    [credits setShadowOffset:CGSizeMake(0, 1)];
-    [credits setBackgroundColor:[UIColor clearColor]];
-    [credits setText:kIASKCredits];
-    [credits sizeToFit];
-    
-    UIView* view = [[[UIView alloc] initWithFrame:CGRectMake(0, 0, kIASKCreditsViewWidth, credits.frame.size.height + 6 + 11)] autorelease];
-    [view setBackgroundColor:[UIColor clearColor]];
-    
-    CGRect frame = credits.frame;
-    frame.origin.y = 8;
-    frame.origin.x = 16;
-    frame.size.width = kIASKCreditsViewWidth;
-    credits.frame = frame;
-    
-    [view addSubview:credits];
-    [view sizeToFit];
-    
-    return view;
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section {
-    if (!_showCreditsFooter || section != [self.settingsReader numberOfSections]-1) return 0.0f;
-    
-    UIView* view = [self tableView:tableView viewForFooterInSection:section];
-    if (view != nil) {
-      return view.frame.size.height;
-    }
-    return -1;
+- (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
+{
+	if (_showCreditsFooter && (section == [self.settingsReader numberOfSections]-1)) {
+		// show credits since this is the last section
+		NSString *footerText = [self.settingsReader footerTextForSection:section];
+		if ((footerText == nil) || ([footerText length] == 0)) {
+			// show the credits on their own
+			return kIASKCredits;
+		} else {
+			// show the credits below the app's FooterText
+			return [NSString stringWithFormat:@"%@\n\n%@", footerText, kIASKCredits];
+		}
+	} else {
+		return [self.settingsReader footerTextForSection:section];
+	}
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {

--- a/InAppSettingsKit/Models/IASKSettingsReader.h
+++ b/InAppSettingsKit/Models/IASKSettingsReader.h
@@ -19,6 +19,7 @@
 #define kIASKPreferenceSpecifiers             @"PreferenceSpecifiers"
 #define kIASKType                             @"Type"
 #define kIASKTitle                            @"Title"
+#define kIASKFooterText                       @"FooterText"
 #define kIASKKey                              @"Key"
 #define kIASKFile                             @"File"
 #define kIASKDefaultValue                     @"DefaultValue"
@@ -105,6 +106,7 @@ __VA_ARGS__ \
 - (IASKSpecifier*)specifierForIndexPath:(NSIndexPath*)indexPath;
 - (IASKSpecifier*)specifierForKey:(NSString*)key;
 - (NSString*)titleForSection:(NSInteger)section;
+- (NSString*)footerTextForSection:(NSInteger)section;
 - (NSString*)titleForStringId:(NSString*)stringId;
 - (NSString*)bundlePath;
 - (NSString*)pathForImageNamed:(NSString*)image;

--- a/InAppSettingsKit/Models/IASKSettingsReader.m
+++ b/InAppSettingsKit/Models/IASKSettingsReader.m
@@ -141,6 +141,14 @@ dataSource=_dataSource;
     return nil;
 }
 
+- (NSString*)footerTextForSection:(NSInteger)section {
+    if ([self _sectionHasHeading:section]) {
+        NSDictionary *dict = [[[self dataSource] objectAtIndex:section] objectAtIndex:kIASKSectionHeaderIndex];
+        return [_bundle localizedStringForKey:[dict objectForKey:kIASKFooterText] value:[dict objectForKey:kIASKFooterText] table:@"Root"];
+    }
+    return nil;
+}
+
 - (NSString*)titleForStringId:(NSString*)stringId {
     return [_bundle localizedStringForKey:stringId value:stringId table:@"Root"];
 }


### PR DESCRIPTION
I added support for PSGroupSpecifier's FooterText, which is new for iOS4.
I replaced the viewForFooterInSection/heightForFooterInSection with titleForFooterInSection, but you might need to keep both to accommodate iOS 3.x.

Cheers,
Dave
