### PR TITLE
PSGroupSpecifier items are truncated.

### DIFF
--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -339,7 +339,7 @@ CGRect IASKCGRectSwap(CGRect rect);
 	NSString *title;
 	if ((title = [self tableView:tableView titleForHeaderInSection:section])) {
 		CGSize size = [title sizeWithFont:[UIFont boldSystemFontOfSize:[UIFont labelFontSize]] 
-						constrainedToSize:CGSizeMake(tableView.frame.size.width - 2*kIASKHorizontalPaddingGroupTitles, tableView.frame.size.height)
+						constrainedToSize:CGSizeMake(tableView.frame.size.width - 2*kIASKHorizontalPaddingGroupTitles, INFINITY)
 							lineBreakMode:UILineBreakModeWordWrap];
 		return size.height+kIASKVerticalPaddingGroupTitles;
 	}


### PR DESCRIPTION
InAppSettingsKit truncates PSGroupSpecifier after a page. The Settings.app displays very long PSGroupSpecifiers.

This patch removes the limit in InAppSettingsKit.
