### PR TITLE
Support for 3.0 devices

### DIFF
--- a/InAppSettingsKit/Models/IASKSettingsReader.m
+++ b/InAppSettingsKit/Models/IASKSettingsReader.m
@@ -51,11 +51,12 @@ dataSource=_dataSource;
 									stringByDeletingPathExtension] // removes potential '.inApp'
 								   lastPathComponent] // strip absolute path
 								  stringByReplacingOccurrencesOfString:[self platformSuffix] withString:@""]; // removes potential '~device' (~ipad, ~iphone)
-		if([_bundle URLForResource:self.localizationTable withExtension:@"strings"] == nil){
+
+    NSURL *resourceURL = [NSURL fileURLWithPath:[_bundle pathForResource:self.localizationTable ofType:@"strings"]];
+    if(resourceURL == nil){
 			// Could not find the specified localization: use default
 			self.localizationTable = @"Root";
 		}
-
         if (_settingsBundle) {
             [self _reinterpretBundle:_settingsBundle];
         }


### PR DESCRIPTION
A very small change to to the code that enables a 3.0 device to use the InAppSettingsKit. The change was tested against the sample application without any issues. However, it might merit testing against projects that use the ~DEVICE pattern. But I don't think the changes I implemented would impact this.
