### PR TITLE
Message sent to deallocated instance...

### DIFF
--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -191,6 +191,7 @@ CGRect IASKCGRectSwap(CGRect rect);
 	if ([self.currentFirstResponder canResignFirstResponder]) {
 		[self.currentFirstResponder resignFirstResponder];
 	}
+	[NSObject cancelPreviousPerformRequestsWithTarget:self];
 	[super viewWillDisappear:animated];
 }
 


### PR DESCRIPTION
The sample app retains the settings view controller. But if an app doesn't do this and the keyboard is visible while the controller is hidden, I get a message sent to a deallocated instance.

I think that's because of the delayed scroll when the keyboard disappears. This commit prevents the crash.
