### PR TITLE
Orientation fix in IASKSpecifierValuesViewController

### DIFF
--- a/InAppSettingsKit/Controllers/IASKSpecifierValuesViewController.m
+++ b/InAppSettingsKit/Controllers/IASKSpecifierValuesViewController.m
@@ -83,7 +83,7 @@
 
 
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation {
-    return (interfaceOrientation == UIInterfaceOrientationPortrait) || (interfaceOrientation == UIInterfaceOrientationPortraitUpsideDown);
+    return YES;
 }
 
 - (void)didReceiveMemoryWarning {


### PR DESCRIPTION
IASKSpecifierValuesViewController currently works in portrait mode only - here's a quick fix for that.
