### PR TITLE
Backward-compatibility in init

### DIFF
--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -97,6 +97,10 @@ CGRect IASKCGRectSwap(CGRect rect);
 }
 
 #pragma mark standard view controller methods
+- (id)init {
+    return [self initWithNibName:@"IASKAppSettingsView" bundle:nil];
+}
+
 - (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
     if ((self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil])) {
         // If set to YES, will display credits for InAppSettingsKit creators


### PR DESCRIPTION
This patch adds API backward-compatibilty for changes in 88a9ebcb. It might save a few users from having to search for the change (which unfortunately breaks quietly).

PS: See you at macoun ;)
