### PR TITLE
Now you can set the tintColor of 'Done' Button

### DIFF
--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.h
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.h
@@ -57,6 +57,7 @@
     
     UIBarButtonItem         *_doneButton;
     UIImage                 *_doneButtonImage;
+    UIColor                 *_doneButtonColor;
 }
 
 @property (nonatomic, assign) IBOutlet id delegate;
@@ -66,6 +67,7 @@
 @property (nonatomic, assign) BOOL showCreditsFooter;
 @property (nonatomic, assign) BOOL showDoneButton;
 @property (nonatomic, assign) UIImage *doneButtonImage;
+@property (nonatomic, assign) UIColor *doneButtonColor;
 
 - (void)synchronizeSettings;
 - (IBAction)dismiss:(id)sender;

--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -65,6 +65,7 @@ CGRect IASKCGRectSwap(CGRect rect);
 @synthesize settingsStore = _settingsStore;
 @synthesize doneButton = _doneButton;
 @synthesize doneButtonImage = _doneButtonImage;
+@synthesize doneButtonColor = _doneButtonColor;
 
 #pragma mark accessors
 - (IASKSettingsReader*)settingsReader {
@@ -176,6 +177,8 @@ CGRect IASKCGRectSwap(CGRect rect);
             save.frame = CGRectMake(0.f, 0.f, _doneButtonImage.size.width, _doneButtonImage.size.height);
             UIBarButtonItem *saveButtonItem = [[[UIBarButtonItem alloc] initWithCustomView: save] autorelease];
             _doneButton = saveButtonItem;
+        } else if (_doneButtonColor != nil) {
+            _doneButton.tintColor = _doneButtonColor;
         }
         
         self.navigationItem.rightBarButtonItem = _doneButton;


### PR DESCRIPTION
If you want to use a different color than the default, now you can.

Use the next syntax:

<code>self.appSettingsViewController.doneButtonColor = [UIColor
colorWithRed: 114.f/255.f green: 158.f/255.f blue: 111.f/255.f alpha:
1.f];</code>

and you have your 'Done' button with your favorite tint.
