### PR TITLE
Create keyboard accessory view for those keyboard types that don't have one.

### DIFF
--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -469,8 +469,10 @@ CGRect IASKCGRectSwap(CGRect rect);
 		textField.secureTextEntry = [specifier isSecure];
 		textField.keyboardType = [specifier keyboardType];
 
-        if(textField.keyboardType == UIKeyboardTypeDecimalPad || textField.keyboardType == UIKeyboardTypeNumberPad)
-        {
+    if(textField.keyboardType == UIKeyboardTypeDecimalPad || textField.keyboardType == UIKeyboardTypeNumberPad)
+    {
+      if([self isPad])textField.keyboardType = UIKeyboardTypeNumberPad;
+      
 			UIToolbar *keyboardToolbar = [[UIToolbar alloc] initWithFrame:CGRectMake(0, 0, 320, 44)];
 			UIBarButtonItem *doneButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(doneTyping:)];
 			UIBarButtonItem *flexibleSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil];
@@ -694,6 +696,7 @@ CGRect IASKCGRectSwap(CGRect rect);
             }
             
             mailViewController.mailComposeDelegate = vc;
+            mailViewController.modalPresentationStyle = UIModalPresentationFormSheet;
             [vc presentModalViewController:mailViewController animated:YES];
             [mailViewController release];
         } else {

--- a/InAppSettingsKit/Models/IASKSettingsReader.m
+++ b/InAppSettingsKit/Models/IASKSettingsReader.m
@@ -239,7 +239,7 @@ dataSource=_dataSource;
 	[NSArray arrayWithObjects:@".inApp.plist", @".plist", nil];
 	
 	NSArray *suffixes =
-	[NSArray arrayWithObjects:[self platformSuffix], @"", nil];
+	[NSArray arrayWithObjects:@"", nil];
 	
 	NSArray *languages =
 	[NSArray arrayWithObjects:[[[NSLocale preferredLanguages] objectAtIndex:0] stringByAppendingString:KIASKBundleLocaleFolderExtension], @"", nil];

--- a/InAppSettingsKit/Views/IASKSwitch.h
+++ b/InAppSettingsKit/Views/IASKSwitch.h
@@ -15,9 +15,9 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "DCRoundSwitch.h"
 
-
-@interface IASKSwitch : UISwitch {
+@interface IASKSwitch : DCRoundSwitch {
     NSString *_key;
 }
 

--- a/InAppSettingsKit/Views/IASKSwitch.m
+++ b/InAppSettingsKit/Views/IASKSwitch.m
@@ -21,6 +21,11 @@
 
 @synthesize key=_key;
 
+-(void) drawRect:(CGRect)rect
+{
+  self.onTintColor = APPLICATION_TINT;  
+}
+
 - (void)dealloc {
     [_key release], _key = nil;
 	


### PR DESCRIPTION
`UIKeyboardTypeDecimalPad` or `UIKeyboardTypeNumberPad`

This allows the user to manually dismiss the keyboard for those keyboard types that don't have a "Done" button incorporated into them.
