### PR TITLE
iOS5 [UINavigationBar appearance] confuses MFMailComposeViewController inside IAK

### DIFF
--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -642,8 +642,13 @@ CGRect IASKCGRectSwap(CGRect rect);
         [tableView deselectRowAtIndexPath:indexPath animated:YES];
         if ([MFMailComposeViewController canSendMail]) {
             MFMailComposeViewController *mailViewController = [[MFMailComposeViewController alloc] init];
-            mailViewController.navigationBar.barStyle = self.navigationController.navigationBar.barStyle;
-			mailViewController.navigationBar.tintColor = self.navigationController.navigationBar.tintColor;
+
+            // modifications by mman
+            if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+                mailViewController.navigationBar.barStyle = UIBarStyleDefault;
+                mailViewController.navigationBar.tintColor = nil;
+                mailViewController.navigationBar.titleTextAttributes = nil;
+            }
 			
             if ([specifier localizedObjectForKey:kIASKMailComposeSubject]) {
                 [mailViewController setSubject:[specifier localizedObjectForKey:kIASKMailComposeSubject]];


### PR DESCRIPTION
Hi futuretap,

I'm using IAK to my full satisfaction in one of my projects.

While moving my app from UI hacks onto proper iOS5 appearance customization APIs, I have found out that UINavigationBar used inside MFMailComposeViewController triggered from IAKAppSettingsViewController on iPad (and only on iPad) will break the appearance badly.

Apparently MFMailComposeViewController on iOS 5.1 does not use the appearance api fully yet, because on iPhone your master code works absolutely well.

I have basically worked around this problem by asking MFMCVC to use default style when used on iPad.

I'm not asking you to pull in my fix straight as I'm not sure if it's the right way to do, just wanted to let you know about the problem and how I solved it.

thanx,
Martin
