### PR TITLE
Another bug fix to eliminate potential flicker when displaying specifier values

### DIFF
--- a/InAppSettingsKit/Controllers/IASKSpecifierValuesViewController.m
+++ b/InAppSettingsKit/Controllers/IASKSpecifierValuesViewController.m
@@ -181,7 +181,7 @@
 #pragma mark Notifications
 
 - (void)userDefaultsDidChange {
-	NSIndexPath *oldCheckedItem = [self.checkedItem retain];
+	NSIndexPath *oldCheckedItem = [[self.checkedItem retain] autorelease];
 	if(_currentSpecifier) {
 		[self updateCheckedItem];
 	}
@@ -190,7 +190,6 @@
 	if (![self.checkedItem isEqual:oldCheckedItem]) {
 		[_tableView reloadData];
 	}
-	[oldCheckedItem release];
 }
 
 @end


### PR DESCRIPTION
oldCheckedItem might be released and deallocated during [self updateCheckedItem], which would ultimately trigger an extraneous [_tableView reloadData] on line 191; we explicitly retain the object to prevent this.
