### PR TITLE
Clear navigationController.delegate if the settings view controller is a...

### DIFF
--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -237,6 +237,9 @@ CGRect IASKCGRectSwap(CGRect rect);
 
 - (void)navigationController:(UINavigationController *)navigationController willShowViewController:(UIViewController *)viewController animated:(BOOL)animated {
 	if (![viewController isKindOfClass:[IASKAppSettingsViewController class]] && ![viewController isKindOfClass:[IASKSpecifierValuesViewController class]]) {
+		if (navigationController.delegate == self)
+			// Clear the navController's reference here, since our reference to the navController already be invalid
+			navigationController.delegate = nil;
 		[self dismiss:nil];
 	}
 }


### PR DESCRIPTION
...bout to be dismissed.

I'm using InAppSettingsKit in an ARC-enabled app, with the -fno-objc-arc option to compile this code.

In my testing, self.navigationController returns nil in -[IASKAppSettingsViewController dismiss:], so
navigationController.delegate holds a stale reference to the view controller after it is deallocated.
