### PR TITLE
Remove navController delegate methods from IASKAppSettingsViewController

### DIFF
--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.h
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.h
@@ -58,7 +58,7 @@
 @end
 
 
-@interface IASKAppSettingsViewController : UITableViewController <IASKViewController, UITextFieldDelegate, UINavigationControllerDelegate, MFMailComposeViewControllerDelegate> {
+@interface IASKAppSettingsViewController : UITableViewController <IASKViewController, UITextFieldDelegate, MFMailComposeViewControllerDelegate> {
 	id<IASKSettingsDelegate>  _delegate;
     
     NSMutableArray          *_viewList;

--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -173,7 +173,6 @@ CGRect IASKCGRectSwap(CGRect rect);
 	}
 	
 	self.navigationItem.rightBarButtonItem = nil;
-	self.navigationController.delegate = self;
 	if (_showDoneButton) {
 		UIBarButtonItem *buttonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone 
 																					target:self 
@@ -216,10 +215,8 @@ CGRect IASKCGRectSwap(CGRect rect);
 - (void)viewDidDisappear:(BOOL)animated {
 	[[NSNotificationCenter defaultCenter] removeObserver:self];
 
-	if (!self.navigationController.delegate) {
-		// hide the keyboard when we're popping from the navigation controller
-		[self.currentFirstResponder resignFirstResponder];
-	}
+    // hide the keyboard
+    [self.currentFirstResponder resignFirstResponder];
 	
 	[super viewDidDisappear:animated];
 }
@@ -233,12 +230,6 @@ CGRect IASKCGRectSwap(CGRect rect);
     [super didReceiveMemoryWarning];
 	
 	// Release any cached data, images, etc that aren't in use.
-}
-
-- (void)navigationController:(UINavigationController *)navigationController willShowViewController:(UIViewController *)viewController animated:(BOOL)animated {
-	if (![viewController isKindOfClass:[IASKAppSettingsViewController class]] && ![viewController isKindOfClass:[IASKSpecifierValuesViewController class]]) {
-		[self dismiss:nil];
-	}
 }
 
 - (void)dealloc {
@@ -261,7 +252,6 @@ CGRect IASKCGRectSwap(CGRect rect);
 
 - (IBAction)dismiss:(id)sender {
 	[self.settingsStore synchronize];
-	self.navigationController.delegate = nil;
 	
 	if (self.delegate && [self.delegate conformsToProtocol:@protocol(IASKSettingsDelegate)]) {
 		[self.delegate settingsViewControllerDidEnd:self];
@@ -585,7 +575,6 @@ CGRect IASKCGRectSwap(CGRect rect);
 			if ([vc respondsToSelector:@selector(setSettingsStore:)]) {
 				[vc performSelector:@selector(setSettingsStore:) withObject:self.settingsStore];
 			}
-			self.navigationController.delegate = nil;
             [self.navigationController pushViewController:vc animated:YES];
             [vc performSelector:@selector(release)];
             return;


### PR DESCRIPTION
This change is based on comments on a previous pull-request, suggesting that
setting navigationController.delegate was added to work around a keyboard display issue,
but might not be required since the change to UITableViewController.

see:
https://github.com/futuretap/InAppSettingsKit/pull/146#issuecomment-5575879
