### PR TITLE
Workaround for number pad keyboard on iPhone.

### DIFF
--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -150,6 +150,10 @@ CGRect IASKCGRectSwap(CGRect rect);
   if ([self isPad]) {
     self.tableView.separatorStyle = UITableViewCellSeparatorStyleSingleLineEtched;
   }
+    UITapGestureRecognizer *tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(singleTapToEndEdit:)];   
+    tapGesture.cancelsTouchesInView = NO;
+    [self.tableView addGestureRecognizer:tapGesture];
+    [tapGesture release];
 }
 
 - (void)viewDidUnload {
@@ -733,6 +737,9 @@ CGRect IASKCGRectSwap(CGRect rect);
 	return YES;
 }
 
+- (void)singleTapToEndEdit:(UIGestureRecognizer *)sender {
+    [self.tableView endEditing:NO];
+}
 
 #pragma mark Notifications
 


### PR DESCRIPTION
Add a simple tap gesture recognizer on the table view that will end
editing if tapping on the table view. This will hide the number pad on
the iPhone which does not have a way to dismiss the keyboard as soon as
you tap on another field that has no keyboard (e.g. a slider or switch)
or into the background.
