### PR TITLE
fix crash on button toggle

### DIFF
--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -346,7 +346,7 @@ CGRect IASKCGRectSwap(CGRect rect);
 }
 
 - (void)toggledValue:(id)sender {
-    IASKSwitch *toggle    = (IASKSwitch*)sender;
+    IASKSwitch *toggle    = [[(IASKSwitch*)sender retain] autorelease];
     IASKSpecifier *spec   = [_settingsReader specifierForKey:[toggle key]];
     
     if ([toggle isOn]) {
@@ -372,7 +372,7 @@ CGRect IASKCGRectSwap(CGRect rect);
 }
 
 - (void)sliderChangedValue:(id)sender {
-    IASKSlider *slider = (IASKSlider*)sender;
+    IASKSlider *slider = [[(IASKSlider*)sender retain] autorelease];
     [self.settingsStore setFloat:[slider value] forKey:[slider key]];
     [[NSNotificationCenter defaultCenter] postNotificationName:kIASKAppSettingChanged
                                                         object:[slider key]
@@ -809,7 +809,7 @@ CGRect IASKCGRectSwap(CGRect rect);
 }
 
 - (void)_textChanged:(id)sender {
-    IASKTextField *text = (IASKTextField*)sender;
+    IASKTextField *text = [[(IASKTextField*)sender retain] autorelease];
     [_settingsStore setObject:[text text] forKey:[text key]];
     [[NSNotificationCenter defaultCenter] postNotificationName:kIASKAppSettingChanged
                                                         object:[text key]


### PR DESCRIPTION
writing to the store can toggle a cell reload, which
might prematurely release the IASKSwitch/Slider that
is used later in this method. Easy fix is to do
the retain] autorelease] dance.

fixes #159
