### PR TITLE
Fix over-released assign properties

### DIFF
--- a/InAppSettingsKit/Views/IASKPSSliderSpecifierViewCell.m
+++ b/InAppSettingsKit/Views/IASKPSSliderSpecifierViewCell.m
@@ -88,7 +88,6 @@
 }	
 
 - (void)dealloc {
-    [_slider release], _slider = nil;
 	_minImage.image = nil;
 	_maxImage.image = nil;
     [super dealloc];

--- a/InAppSettingsKit/Views/IASKPSTextFieldSpecifierViewCell.m
+++ b/InAppSettingsKit/Views/IASKPSTextFieldSpecifierViewCell.m
@@ -70,7 +70,6 @@
 
 
 - (void)dealloc {
-    [_textField release], _textField = nil;
     [super dealloc];
 }
 


### PR DESCRIPTION
With d863901 these properties are autoreleased on creation and then released again on dealloc. That causes a crash.

Since the properties are declared as "assign", I removed the release in dealloc.
