### PR TITLE
Minor rename so constants are consistent

### DIFF
--- a/InAppSettingsKit/Models/IASKSettingsReader.h
+++ b/InAppSettingsKit/Models/IASKSettingsReader.h
@@ -50,7 +50,7 @@
 #define kIASKKeyboardNumberPad                @"NumberPad"
 #define kIASKKeyboardDecimalPad               @"DecimalPad"
 
-#define KIASKKeyboardURL                      @"URL"
+#define kIASKKeyboardURL                      @"URL"
 #define kIASKKeyboardEmailAddress             @"EmailAddress"
 #define kIASKAutoCapNone                      @"None"
 #define kIASKAutoCapSentences                 @"Sentences"
@@ -82,7 +82,7 @@
 #define kIASKBundleFolder                     @"Settings.bundle"
 #define kIASKBundleFolderAlt                  @"InAppSettings.bundle"
 #define kIASKBundleFilename                   @"Root.plist"
-#define KIASKBundleLocaleFolderExtension      @".lproj"
+#define kIASKBundleLocaleFolderExtension      @".lproj"
 
 #define kIASKAppSettingChanged                @"kAppSettingChanged"
 

--- a/InAppSettingsKit/Models/IASKSettingsReader.m
+++ b/InAppSettingsKit/Models/IASKSettingsReader.m
@@ -261,7 +261,7 @@ hiddenKeys = _hiddenKeys;
 	[NSArray arrayWithObjects:[self platformSuffix], @"", nil];
 	
 	NSArray *languages =
-	[NSArray arrayWithObjects:[[[NSLocale preferredLanguages] objectAtIndex:0] stringByAppendingString:KIASKBundleLocaleFolderExtension], @"", nil];
+	[NSArray arrayWithObjects:[[[NSLocale preferredLanguages] objectAtIndex:0] stringByAppendingString:kIASKBundleLocaleFolderExtension], @"", nil];
 	
 	NSString *path = nil;
 	NSFileManager *fileManager = [NSFileManager defaultManager];

--- a/InAppSettingsKit/Models/IASKSpecifier.m
+++ b/InAppSettingsKit/Models/IASKSpecifier.m
@@ -199,7 +199,7 @@
 			return UIKeyboardTypeNumbersAndPunctuation;
 		}
     }
-    else if ([[_specifierDict objectForKey:kIASKKeyboardType] isEqualToString:KIASKKeyboardURL]) {
+    else if ([[_specifierDict objectForKey:kIASKKeyboardType] isEqualToString:kIASKKeyboardURL]) {
         return UIKeyboardTypeURL;
     }
     else if ([[_specifierDict objectForKey:kIASKKeyboardType] isEqualToString:kIASKKeyboardEmailAddress]) {


### PR DESCRIPTION
Rename KIASKKeyboardType to kIASKKeyboardType. This was the only constant that, for whatever reason, didn't start with a lowercase k.
