### PR TITLE
Support ShortTitles for Multi Value Elements (introduced in IOS 5.0)

### DIFF
--- a/InAppSettingsKit/Models/IASKSettingsReader.h
+++ b/InAppSettingsKit/Models/IASKSettingsReader.h
@@ -35,6 +35,7 @@
 #define kIASKAutoCorrectionType               @"AutocorrectionType"
 #define kIASKValues                           @"Values"
 #define kIASKTitles                           @"Titles"
+#define kIASKShortTitles                      @"ShortTitles"
 #define kIASKViewControllerClass              @"IASKViewControllerClass"
 #define kIASKViewControllerSelector           @"IASKViewControllerSelector"
 #define kIASKButtonClass                      @"IASKButtonClass"

--- a/InAppSettingsKit/Models/IASKSpecifier.m
+++ b/InAppSettingsKit/Models/IASKSpecifier.m
@@ -52,7 +52,8 @@
 - (void)_reinterpretValues:(NSDictionary*)specifierDict {
     NSArray *values = [_specifierDict objectForKey:kIASKValues];
     NSArray *titles = [_specifierDict objectForKey:kIASKTitles];
-    
+    NSArray *shortTitles = [_specifierDict objectForKey:kIASKShortTitles];
+
     NSMutableDictionary *multipleValuesDict = [[[NSMutableDictionary alloc] init] autorelease];
     
     if (values) {
@@ -61,6 +62,10 @@
 	
     if (titles) {
 		[multipleValuesDict setObject:titles forKey:kIASKTitles];
+	}
+    
+    if (shortTitles) {
+		[multipleValuesDict setObject:shortTitles forKey:kIASKShortTitles];
 	}
     
     [self setMultipleValuesDict:multipleValuesDict];
@@ -103,7 +108,10 @@
 
 - (NSString*)titleForCurrentValue:(id)currentValue {
 	NSArray *values = [self multipleValues];
-	NSArray *titles = [self multipleTitles];
+	NSArray *titles = [self multipleShortTitles];
+    if (!titles)
+        titles = [self multipleTitles];
+
 	if (values.count != titles.count) {
 		return nil;
 	}
@@ -128,6 +136,10 @@
 
 - (NSArray*)multipleTitles {
     return [_multipleValuesDict objectForKey:kIASKTitles];
+}
+
+- (NSArray*)multipleShortTitles {
+    return [_multipleValuesDict objectForKey:kIASKShortTitles];
 }
 
 - (NSString*)file {

--- a/InAppSettingsKitSampleApp/Settings.bundle/Complete.plist
+++ b/InAppSettingsKitSampleApp/Settings.bundle/Complete.plist
@@ -572,6 +572,34 @@
 			<key>Type</key>
 			<string>PSMultiValueSpecifier</string>
 			<key>Title</key>
+			<string>MultiVal w/ short titles</string>
+			<key>Key</key>
+			<string>multivalue_shorttitles</string>
+			<key>DefaultValue</key>
+			<integer>2</integer>
+			<key>Values</key>
+			<array>
+				<integer>1</integer>
+				<integer>2</integer>
+				<integer>3</integer>
+			</array>
+			<key>Titles</key>
+			<array>
+				<string>One (this is the long title)</string>
+				<string>Two (this is the long title)</string>
+				<string>Three (this is the long title)</string>
+			</array>
+			<key>ShortTitles</key>
+			<array>
+				<string>One</string>
+				<string>Two</string>
+				<string>Three</string>
+			</array>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSMultiValueSpecifier</string>
+			<key>Title</key>
 			<string>EMPTY</string>
 			<key>Key</key>
 			<string>multivalue_notitle</string>


### PR DESCRIPTION
Added support for the ShortTitles key in Multi Value elements. 
Also added a usage example in the sample app.

for a description of this key, see: http://developer.apple.com/library/ios/#documentation/PreferenceSettings/Conceptual/SettingsApplicationSchemaReference/Articles/PSMultiValueSpecifier.html#//apple_ref/doc/uid/TP40007016-SW1 
