### PR TITLE
Enable searching a title when "currentValue" is NSNumber.

### DIFF
--- a/InAppSettingsKit/Controllers/IASKSpecifierValuesViewController.m
+++ b/InAppSettingsKit/Controllers/IASKSpecifierValuesViewController.m
@@ -149,7 +149,7 @@
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     UITableViewCell *cell   = [tableView dequeueReusableCellWithIdentifier:kCellValue];
     NSArray *titles         = [_currentSpecifier multipleTitles];
-	
+
     if (!cell) {
         cell = [[[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:kCellValue] autorelease];
     }
@@ -161,7 +161,18 @@
     }
 	
 	@try {
-		[[cell textLabel] setText:[self.settingsReader titleForStringId:[titles objectAtIndex:indexPath.row]]];
+        NSString *title = @"";
+        if (indexPath.row < [titles count]) {
+            title = [self.settingsReader titleForStringId:[titles objectAtIndex:indexPath.row]];
+        }
+        else {
+            // show the value as a substitute of the title when the title for current indexPath is not exist.
+            NSArray *values = [_currentSpecifier multipleValues];
+            if (indexPath.row < [values count]) {
+                title = [NSString stringWithFormat:@"%@", [values objectAtIndex:indexPath.row]];
+            }
+        }
+		[[cell textLabel] setText:title];
 	}
 	@catch (NSException * e) {}
     return cell;

--- a/InAppSettingsKit/Models/IASKSpecifier.m
+++ b/InAppSettingsKit/Models/IASKSpecifier.m
@@ -101,21 +101,49 @@
     return [_specifierDict objectForKey:kIASKType];
 }
 
-- (NSString*)titleForCurrentValue:(id)currentValue {
-	NSArray *values = [self multipleValues];
-	NSArray *titles = [self multipleTitles];
-	if (values.count != titles.count) {
-		return nil;
-	}
+- (NSString *)titleForCurrentValue:(id)currentValue {
+    NSArray *values = [self multipleValues];
+    NSArray *titles = [self multipleTitles];
+    if (values.count != titles.count) {
+        return nil;
+    }
+    
     NSInteger keyIndex = [values indexOfObject:currentValue];
-	if (keyIndex == NSNotFound) {
-		return nil;
-	}
-	@try {
-		return [self.settingsReader titleForStringId:[titles objectAtIndex:keyIndex]];
-	}
-	@catch (NSException * e) {}
-	return nil;
+    if (keyIndex == NSNotFound) {
+        
+        // When currentValue is NSNumber
+        if ([currentValue isKindOfClass:[NSNumber class]]) {
+            
+            for (NSInteger i=0; i<[values count]; i++) {
+                
+                id aValue = [values objectAtIndex:i];
+                
+                if (![aValue respondsToSelector:@selector(floatValue)]) {
+                    continue;
+                }
+                
+                if ([aValue floatValue] == [currentValue floatValue]) {
+                    keyIndex = i;
+                    break;
+                }
+            }
+            
+            if (keyIndex == NSNotFound) {
+                return nil;
+            }
+        }
+        else {
+            return nil;
+        }
+    }
+    
+    @try {
+        return [self.settingsReader titleForStringId:[titles objectAtIndex:keyIndex]];
+    }
+    @catch (NSException * e) {
+    }
+    
+    return nil;
 }
 
 - (NSInteger)multipleValuesCount {

--- a/InAppSettingsKit/Models/IASKSpecifier.m
+++ b/InAppSettingsKit/Models/IASKSpecifier.m
@@ -104,10 +104,7 @@
 - (NSString *)titleForCurrentValue:(id)currentValue {
     NSArray *values = [self multipleValues];
     NSArray *titles = [self multipleTitles];
-    if (values.count != titles.count) {
-        return nil;
-    }
-    
+
     NSInteger keyIndex = [values indexOfObject:currentValue];
     if (keyIndex == NSNotFound) {
         
@@ -115,7 +112,7 @@
         if ([currentValue isKindOfClass:[NSNumber class]]) {
             
             for (NSInteger i=0; i<[values count]; i++) {
-                
+            
                 id aValue = [values objectAtIndex:i];
                 
                 if (![aValue respondsToSelector:@selector(floatValue)]) {
@@ -136,13 +133,22 @@
             return nil;
         }
     }
-    
+
     @try {
-        return [self.settingsReader titleForStringId:[titles objectAtIndex:keyIndex]];
+        NSString *title = @"";
+        if (keyIndex < [titles count]) {
+            title = [self.settingsReader titleForStringId:[titles objectAtIndex:keyIndex]];
+        }
+        // return currentValue as a substitute of the title when the title for currentValue is not exist.
+        if (!([title length] > 0)) {
+            title = [NSString stringWithFormat:@"%@", currentValue];
+        }
+        NSLog(@"title:%@", title);
+        return title;
     }
     @catch (NSException * e) {
     }
-    
+
     return nil;
 }
 
@@ -292,17 +298,17 @@
 - (UITextAlignment)textAlignment
 {
     if ([[_specifierDict objectForKey:kIASKTextLabelAlignment] isEqualToString:kIASKTextLabelAlignmentLeft]) {
-        return NSTextAlignmentLeft;
+        return UITextAlignmentLeft;
     } else if ([[_specifierDict objectForKey:kIASKTextLabelAlignment] isEqualToString:kIASKTextLabelAlignmentCenter]) {
-        return NSTextAlignmentCenter;
+        return UITextAlignmentCenter;
     } else if ([[_specifierDict objectForKey:kIASKTextLabelAlignment] isEqualToString:kIASKTextLabelAlignmentRight]) {
-        return NSTextAlignmentRight;
+        return UITextAlignmentRight;
     }
     if ([self.type isEqualToString:kIASKButtonSpecifier] && !self.cellImage) {
-		return NSTextAlignmentCenter;
+		return UITextAlignmentCenter;
 	} else if ([self.type isEqualToString:kIASKPSMultiValueSpecifier] || [self.type isEqualToString:kIASKPSTitleValueSpecifier]) {
-		return NSTextAlignmentRight;
+		return UITextAlignmentRight;
 	}
-	return NSTextAlignmentLeft;
+	return UITextAlignmentLeft;
 }
 @end


### PR DESCRIPTION
Fixed to enable searching a title when the argument "currentValue" is NSNumber. It's useful when using a static userDefaults.plist, because the values' types are allowed to be not only NSString but also NSNumber.