### PR TITLE
More layout tweaks for iOS 7

### DIFF
--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -406,7 +406,7 @@ CGRect IASKCGRectSwap(CGRect rect);
 		CGSize size = [title sizeWithFont:[UIFont boldSystemFontOfSize:[UIFont labelFontSize]] 
 						constrainedToSize:CGSizeMake(tableView.frame.size.width - 2*kIASKHorizontalPaddingGroupTitles, INFINITY)
 							lineBreakMode:NSLineBreakByWordWrapping];
-		return size.height+kIASKVerticalPaddingGroupTitles;
+		return roundf(size.height+kIASKVerticalPaddingGroupTitles);
 	}
 	return 0;
 }


### PR DESCRIPTION
- Fixed missing cell separators on iOS 7 iPad
- Fixed blurry text due to non-integral table view header heights
