### PR TITLE
Fixed warnings when compiling for 64-bit

### DIFF
--- a/InAppSettingsKit/Models/IASKSettingsStore.h
+++ b/InAppSettingsKit/Models/IASKSettingsStore.h
@@ -29,7 +29,7 @@
 - (BOOL)boolForKey:(NSString*)key;
 - (float)floatForKey:(NSString*)key;
 - (double)doubleForKey:(NSString*)key;
-- (int)integerForKey:(NSString*)key;
+- (NSInteger)integerForKey:(NSString*)key;
 - (id)objectForKey:(NSString*)key;
 - (BOOL)synchronize; // Write settings to a permanant storage. Returns YES on success, NO otherwise
 @end

--- a/InAppSettingsKit/Models/IASKSettingsStore.m
+++ b/InAppSettingsKit/Models/IASKSettingsStore.m
@@ -53,8 +53,8 @@
 - (float)floatForKey:(NSString*)key {
     return [[self objectForKey:key] floatValue];
 }
-- (int)integerForKey:(NSString*)key {
-    return [[self objectForKey:key] intValue];
+- (NSInteger)integerForKey:(NSString*)key {
+    return [[self objectForKey:key] integerValue];
 }
 
 - (double)doubleForKey:(NSString*)key {

--- a/InAppSettingsKit/Models/IASKSettingsStoreUserDefaults.m
+++ b/InAppSettingsKit/Models/IASKSettingsStoreUserDefaults.m
@@ -69,7 +69,7 @@
     return [self.defaults doubleForKey:key];
 }
 
-- (int)integerForKey:(NSString*)key {
+- (NSInteger)integerForKey:(NSString*)key {
     return [self.defaults integerForKey:key];
 }
 


### PR DESCRIPTION
Changes the method signature of `-integerForKey:` to match the implementation in NSUserDefaults by using NSInteger instead of int.
