### PR TITLE
copy UINavigationBar titleTextAttributes from presenting view controller

### DIFF
--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -679,6 +679,8 @@ CGRect IASKCGRectSwap(CGRect rect);
             MFMailComposeViewController *mailViewController = [[MFMailComposeViewController alloc] init];
             mailViewController.navigationBar.barStyle = self.navigationController.navigationBar.barStyle;
             mailViewController.navigationBar.tintColor = self.navigationController.navigationBar.tintColor;
+            mailViewController.navigationBar.titleTextAttributes =
+            self.navigationController.navigationBar.titleTextAttributes;
             
             if ([specifier localizedObjectForKey:kIASKMailComposeSubject]) {
                 [mailViewController setSubject:[specifier localizedObjectForKey:kIASKMailComposeSubject]];


### PR DESCRIPTION
Hi guys,

When an MFMailComposeViewController is presented from the IASK view controller, the navigation bar style and tint are carried over from the presenting view controller. This fix also carries over the titleTextAttributes to keep them consistent.
