### PR TITLE
Fixed issue with CUICatalog: Invalid asset name supplied: (null), or invalid scale factor: 2.000000

### DIFF
--- a/InAppSettingsKit/Models/IASKSpecifier.m
+++ b/InAppSettingsKit/Models/IASKSpecifier.m
@@ -247,12 +247,20 @@
 
 - (UIImage *)cellImage
 {
-    return [UIImage imageNamed:[_specifierDict objectForKey:kIASKCellImage]];
+    NSString *imageName = [_specifierDict objectForKey:kIASKCellImage];
+    if( imageName.length == 0 )
+        return nil;
+    
+    return [UIImage imageNamed:imageName];
 }
 
 - (UIImage *)highlightedCellImage
 {
-    return [UIImage imageNamed:[[_specifierDict objectForKey:kIASKCellImage ] stringByAppendingString:@"Highlighted"]];
+    NSString *imageName = [[_specifierDict objectForKey:kIASKCellImage ] stringByAppendingString:@"Highlighted"];
+    if( imageName.length == 0 )
+        return nil;
+
+    return [UIImage imageNamed:imageName];
 }
 
 - (BOOL)adjustsFontSizeToFitWidth {


### PR DESCRIPTION
I can't claim credit for this fix, but in iOS 7 you get the above CUICatalog warning flooding the console. This patch seems to fix it.
