### PR TITLE
Add support for the SupportedUserInterfaceIdioms attribute.

### DIFF
--- a/InAppSettingsKit/Models/IASKSettingsReader.h
+++ b/InAppSettingsKit/Models/IASKSettingsReader.h
@@ -37,6 +37,7 @@
 #define kIASKValues                           @"Values"
 #define kIASKTitles                           @"Titles"
 #define kIASKShortTitles                      @"ShortTitles"
+#define kIASKSupportedUserInterfaceIdioms     @"SupportedUserInterfaceIdioms"
 #define kIASKSubtitle                         @"IASKSubtitle"
 #define kIASKViewControllerClass              @"IASKViewControllerClass"
 #define kIASKViewControllerSelector           @"IASKViewControllerSelector"

--- a/InAppSettingsKit/Models/IASKSettingsReader.m
+++ b/InAppSettingsKit/Models/IASKSettingsReader.m
@@ -141,7 +141,10 @@
             }
             
             IASKSpecifier *newSpecifier = [[IASKSpecifier alloc] initWithSpecifier:specifier];
-            [(NSMutableArray*)[dataSource objectAtIndex:sectionIndex + self.showPrivacySettings] addObject:newSpecifier];
+            if ([newSpecifier.userInterfaceIdioms containsObject:@(UI_USER_INTERFACE_IDIOM())]) {
+                [(NSMutableArray *) [dataSource objectAtIndex:sectionIndex +
+                    self.showPrivacySettings] addObject:newSpecifier];
+            }
         }
     }
     [self setDataSource:dataSource];

--- a/InAppSettingsKit/Models/IASKSpecifier.h
+++ b/InAppSettingsKit/Models/IASKSpecifier.h
@@ -59,4 +59,5 @@
 - (UIImage *)highlightedCellImage;
 - (BOOL)adjustsFontSizeToFitWidth;
 - (NSTextAlignment)textAlignment;
+- (NSArray *)userInterfaceIdioms;
 @end

--- a/InAppSettingsKit/Models/IASKSpecifier.m
+++ b/InAppSettingsKit/Models/IASKSpecifier.m
@@ -296,6 +296,22 @@
 	return NSTextAlignmentLeft;
 }
 
+- (NSArray *)userInterfaceIdioms {
+    NSArray *idiomStrings = _specifierDict[kIASKSupportedUserInterfaceIdioms];
+    if (idiomStrings.count == 0) {
+        return @[@(UIUserInterfaceIdiomPhone), @(UIUserInterfaceIdiomPad)];
+    }
+    NSMutableArray *idioms = [NSMutableArray new];
+    for (NSString *idiomString in idiomStrings) {
+        if ([idiomString isEqualToString:@"Phone"]) {
+            [idioms addObject:@(UIUserInterfaceIdiomPhone)];
+        } else if ([idiomString isEqualToString:@"Pad"]) {
+            [idioms addObject:@(UIUserInterfaceIdiomPad)];
+        }
+    }
+    return idioms;
+}
+
 - (id)valueForKey:(NSString *)key {
 	return [_specifierDict objectForKey:key];
 }


### PR DESCRIPTION
As the documentation says:

| Key | Value type | Value |
| --- | --- | --- |
| SupportedUserInterfaceIdioms | Array | Indicates that the element is displayed only on specific types of devices. The value of this key is an array of strings with the supported idioms. Include the string “Phone” to display the element on iPhone and iPod touch. Include the string to “Pad” to display it on iPad. This key is available in iOS 4.2 and later. |
