### PR TITLE
Fix multiple selection with numeric values.

### DIFF
--- a/InAppSettingsKit/Controllers/IASKSpecifierValuesViewController.m
+++ b/InAppSettingsKit/Controllers/IASKSpecifierValuesViewController.m
@@ -34,14 +34,12 @@
 @synthesize settingsStore = _settingsStore;
 
 - (void) updateCheckedItem {
-    NSInteger index;
-	
 	// Find the currently checked item
-    if([self.settingsStore objectForKey:[_currentSpecifier key]]) {
-      index = [[_currentSpecifier multipleValues] indexOfObject:[self.settingsStore objectForKey:[_currentSpecifier key]]];
-    } else {
-      index = [[_currentSpecifier multipleValues] indexOfObject:[_currentSpecifier defaultValue]];
+    id selectedValue = [self.settingsStore objectForKey:[_currentSpecifier key]];
+    if (!selectedValue) {
+        selectedValue = [_currentSpecifier defaultValue];
     }
+    NSInteger index = [_currentSpecifier multipleValuesIndexOfValue:selectedValue];
 	[self setCheckedItem:[NSIndexPath indexPathForRow:index inSection:0]];
 }
 

--- a/InAppSettingsKit/Models/IASKSpecifier.h
+++ b/InAppSettingsKit/Models/IASKSpecifier.h
@@ -31,6 +31,7 @@
 - (NSString*)key;
 - (NSString*)type;
 - (NSString*)titleForCurrentValue:(id)currentValue;
+- (NSInteger)multipleValuesIndexOfValue:(id)value;
 - (NSInteger)multipleValuesCount;
 - (NSArray*)multipleValues;
 - (NSArray*)multipleTitles;

--- a/InAppSettingsKit/Models/IASKSpecifier.m
+++ b/InAppSettingsKit/Models/IASKSpecifier.m
@@ -117,7 +117,7 @@
 	if (values.count != titles.count) {
 		return nil;
 	}
-    NSInteger keyIndex = [values indexOfObject:currentValue];
+    NSInteger keyIndex = [self multipleValuesIndexOfValue:currentValue];
 	if (keyIndex == NSNotFound) {
 		return nil;
 	}
@@ -127,6 +127,20 @@
 	}
 	@catch (NSException * e) {}
 	return nil;
+}
+
+- (NSInteger)multipleValuesIndexOfValue:(id)value {
+    // Apple's Settings.app ignores the type declared for values and will turn the "5" into @5 e.g.
+    // So we have to convert everything to strings before comparing.
+    NSString *stringValue = [value description];
+    int i = 0;
+    for (id possibleValue in [self multipleValues]) {
+        if ([[possibleValue description] isEqualToString:stringValue]) {
+            return i;
+        }
+        i++;
+    }
+    return NSNotFound;
 }
 
 - (NSInteger)multipleValuesCount {


### PR DESCRIPTION
Apple's Settings.app turns numeric value strings into numbers.
That means updateCheckedItem never found a match.

This happens with "MUL_VAL" in the sample app, for example.
