### PR TITLE
Adapted to work with larger margins on iPhone 6 and 6 Plus

### DIFF
--- a/InAppSettingsKit/Models/IASKSettingsReader.h
+++ b/InAppSettingsKit/Models/IASKSettingsReader.h
@@ -98,8 +98,7 @@
 
 #define kIASKSectionHeaderIndex               0
 
-#define kIASKSliderNoImagesPadding            11
-#define kIASKSliderImagesPadding              43
+#define kIASKSliderImageGap                   10
 
 #define kIASKSpacing                          8
 #define kIASKMinLabelWidth                    97

--- a/InAppSettingsKit/Views/IASKPSSliderSpecifierViewCell.m
+++ b/InAppSettingsKit/Views/IASKPSSliderSpecifierViewCell.m
@@ -51,13 +51,18 @@
 
 - (void)layoutSubviews {
     [super layoutSubviews];
+    
+    UIEdgeInsets padding = (UIEdgeInsets) { 0, kIASKPaddingLeft, 0, kIASKPaddingRight };
+    if ([self respondsToSelector:@selector(layoutMargins)]) {
+        padding = [self layoutMargins];
+    }
 	CGRect  sliderBounds    = _slider.bounds;
     CGPoint sliderCenter    = _slider.center;
     const CGFloat superViewWidth = _slider.superview.frame.size.width;
     
-    sliderCenter.x = superViewWidth / 2;
+    sliderBounds.size.width = superViewWidth - (padding.left + padding.right);
+    sliderCenter.x = padding.left + sliderBounds.size.width / 2;
     sliderCenter.y = self.contentView.center.y;
-    sliderBounds.size.width = superViewWidth - kIASKSliderNoImagesPadding * 2;
 	_minImage.hidden = YES;
 	_maxImage.hidden = YES;
 
@@ -65,18 +70,17 @@
 	if (_minImage.image) {
 		// Min image
 		_minImage.hidden = NO;
-		sliderCenter.x    += (kIASKSliderImagesPadding - kIASKSliderNoImagesPadding) / 2;
-		sliderBounds.size.width  -= (kIASKSliderImagesPadding - kIASKSliderNoImagesPadding);
-        _minImage.center = CGPointMake(_minImage.frame.size.width / 2 + kIASKPaddingLeft,
+        sliderBounds.size.width -= _minImage.frame.size.width + kIASKSliderImageGap;
+        sliderCenter.x += (_minImage.frame.size.width + kIASKSliderImageGap) / 2;
+        _minImage.center = CGPointMake(_minImage.frame.size.width / 2 + padding.left,
                                        self.contentView.center.y);
     }
 	if (_maxImage.image) {
 		// Max image
 		_maxImage.hidden = NO;
-		sliderCenter.x    -= (kIASKSliderImagesPadding - kIASKSliderNoImagesPadding) / 2;
-		sliderBounds.size.width  -= (kIASKSliderImagesPadding - kIASKSliderNoImagesPadding);
-        _maxImage.center = CGPointMake(self.contentView.bounds.size.width - _maxImage.frame.size.width / 2 - kIASKPaddingRight,
-                                       self.contentView.center.y);
+        sliderBounds.size.width  -= kIASKSliderImageGap + _maxImage.frame.size.width;
+		sliderCenter.x    -= (kIASKSliderImageGap + _maxImage.frame.size.width) / 2;
+        _maxImage.center = CGPointMake(superViewWidth - padding.right - _maxImage.frame.size.width /2, self.contentView.center.y );
 	}
 	
 	_slider.bounds = sliderBounds;

--- a/InAppSettingsKit/Views/IASKPSTextFieldSpecifierViewCell.m
+++ b/InAppSettingsKit/Views/IASKPSTextFieldSpecifierViewCell.m
@@ -41,8 +41,13 @@
 - (void)layoutSubviews {
     [super layoutSubviews];
     
+    UIEdgeInsets padding = (UIEdgeInsets) { 0, kIASKPaddingLeft, 0, kIASKPaddingRight };
+    if ([self respondsToSelector:@selector(layoutMargins)]) {
+        padding = [self layoutMargins];
+    }
+    
     // Label
-	CGFloat imageOffset = self.imageView.image ? self.imageView.bounds.size.width + kIASKPaddingLeft : 0;
+	CGFloat imageOffset = self.imageView.image ? self.imageView.bounds.size.width + padding.left : 0;
     CGSize labelSize = [self.textLabel sizeThatFits:CGSizeZero];
 	labelSize.width = MAX(labelSize.width, kIASKMinLabelWidth - imageOffset);
     self.textLabel.frame = (CGRect){self.textLabel.frame.origin, {MIN(kIASKMaxLabelWidth, labelSize.width), self.textLabel.frame.size.height}} ;
@@ -51,14 +56,14 @@
     _textField.center = CGPointMake(_textField.center.x, self.contentView.center.y);
 	CGRect textFieldFrame = _textField.frame;
 	textFieldFrame.origin.x = self.textLabel.frame.origin.x + MAX(kIASKMinLabelWidth - imageOffset, self.textLabel.frame.size.width) + kIASKSpacing;
-	textFieldFrame.size.width = _textField.superview.frame.size.width - textFieldFrame.origin.x - kIASKPaddingRight;
+	textFieldFrame.size.width = _textField.superview.frame.size.width - textFieldFrame.origin.x - padding.right;
 	
 	if (!self.textLabel.text.length) {
-		textFieldFrame.origin.x = kIASKPaddingLeft + imageOffset;
-		textFieldFrame.size.width = self.contentView.bounds.size.width - 2* kIASKPaddingLeft - imageOffset;
+		textFieldFrame.origin.x = padding.left + imageOffset;
+		textFieldFrame.size.width = self.contentView.bounds.size.width - padding.left - padding.right - imageOffset;
 	} else if (_textField.textAlignment == NSTextAlignmentRight) {
 		textFieldFrame.origin.x = self.textLabel.frame.origin.x + labelSize.width + kIASKSpacing;
-		textFieldFrame.size.width = _textField.superview.frame.size.width - textFieldFrame.origin.x - kIASKPaddingRight;
+		textFieldFrame.size.width = _textField.superview.frame.size.width - textFieldFrame.origin.x - padding.right;
 	}
 	_textField.frame = textFieldFrame;
 }


### PR DESCRIPTION
On iPhone 6 the table view has wider margins, which are even wider on iPhone 6 Plus. This led to some visual impurities for sliders, and for text fields that are right aligned. 
