### PR TITLE
resources bundle

### DIFF
--- a/InAppSettingsKit.podspec.json
+++ b/InAppSettingsKit.podspec.json
@@ -16,7 +16,7 @@
     "tag": "2.3"
   },
   "source_files": "InAppSettingsKit/**/*.{h,m}",
-  "resource_bundles": {"InAppSettingsKit": "Resources/*"},
+  "resource_bundles": {"InAppSettingsKit": "InAppSettingsKit/Resources/*"},
   "frameworks": "MessageUI",
   "requires_arc": true
 }


### PR DESCRIPTION
Without this, resources files (language localizations) are left in app package root folder.  This causes iTunes to pickup languages that the host app may not be translated to.

Also, cocoapods recommends putting resources in a bundle:
http://guides.cocoapods.org/syntax/podspec.html#resource_bundles
