### PR TITLE
Update IASKSettingsReader.m

### DIFF
--- a/InAppSettingsKit/Models/IASKSettingsReader.m
+++ b/InAppSettingsKit/Models/IASKSettingsReader.m
@@ -119,6 +119,7 @@
 	
 	if (self.showPrivacySettings) {
 		[dataSource addObjectsFromArray:self.privacySettingsSpecifiers];
+		[dataSource addObject:[NSMutableArray array]];
 	}
 	
     for (NSDictionary *specifierDictionary in preferenceSpecifiers) {


### PR DESCRIPTION
dataSource expects lastObject to be mutable array
In my scenario, privacySettingsSpecifiers were added which added non-mutable array to the dataSource array.  Entering the loop, it expected the last item in dataSource to be a mutable array.
