### PR TITLE
Fix a compiler warning

### DIFF
--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -462,7 +462,7 @@ CGRect IASKCGRectSwap(CGRect rect);
 
 - (UITableViewCell*)tableView:(UITableView *)tableView cellForSpecifier:(IASKSpecifier*)specifier {
 
-	NSString *identifier = [NSString stringWithFormat:@"%@-%lu-%d", specifier.type, specifier.textAlignment, !!specifier.subtitle.length];
+	NSString *identifier = [NSString stringWithFormat:@"%@-%ld-%d", specifier.type, specifier.textAlignment, !!specifier.subtitle.length];
 	UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:identifier];
 	if (cell) {
 		return cell;


### PR DESCRIPTION
This fixes the following warning in IASKAppSettingsViewController:

> Format specifies type 'unsigned long' but the argument has type 'NSTextAlignment' (aka 'enum NSTextAlignment')