### PR TITLE
Remove warnings generated by XCode 6.3 iOS 8.3

### DIFF
--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -138,10 +138,7 @@ CGRect IASKCGRectSwap(CGRect rect);
     }
     self = [super initWithStyle:UITableViewStyleGrouped];
     if (self) {
-        _reloadDisabled = NO;
-        _showDoneButton = YES;
-        // If set to YES, will display credits for InAppSettingsKit creators
-        _showCreditsFooter = YES;
+        [self prepareSelf];
     }
     return self;
 }
@@ -152,7 +149,18 @@ CGRect IASKCGRectSwap(CGRect rect);
         return [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
     }
     NSLog (@"%@ is now deprecated, we are moving away from nibs.", NSStringFromSelector(_cmd));
-    return [self initWithStyle:UITableViewStyleGrouped];
+    self = [super initWithStyle:UITableViewStyleGrouped];
+  if (self) {
+      [self prepareSelf];
+  }
+  return self;
+}
+
+- (void)prepareSelf {
+  _reloadDisabled = NO;
+  _showDoneButton = YES;
+  // If set to YES, will display credits for InAppSettingsKit creators
+  _showCreditsFooter = YES;
 }
 
 - (void)viewDidLoad {


### PR DESCRIPTION
Call super and create a helper method to prepare the appropriate member variables.