### PR TITLE
set contentOffset.y according to contentInset.top

### DIFF
--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -92,7 +92,7 @@ CGRect IASKCGRectSwap(CGRect rect);
 
 - (void)setFile:(NSString *)file {
     _file = [file copy];
-    self.tableView.contentOffset = CGPointMake(0, 0);
+    self.tableView.contentOffset = CGPointMake(0, -self.tableView.contentInset.top);
     self.settingsReader = nil; // automatically initializes itself
     if (!_reloadDisabled) {
 		[self.tableView reloadData];


### PR DESCRIPTION
Settings table view's `contentOffset` property is not set correctly. In some cases, the settings content is not displayed at the top of table view.

You can reproduce this bug by removing [this part of code](https://github.com/futuretap/InAppSettingsKit/blob/master/InAppSettingsKitSampleApp/Classes/MainViewController.m#L45-L46) in sample app, run the sample app, tap _Show Settings(Modal)_, checkout the content offset of the settings table view.