### PR TITLE
Add support for DisplaySortedByTitle

### DIFF
--- a/InAppSettingsKit/Models/IASKSettingsReader.h
+++ b/InAppSettingsKit/Models/IASKSettingsReader.h
@@ -26,6 +26,7 @@
 #define kIASKKey                              @"Key"
 #define kIASKFile                             @"File"
 #define kIASKDefaultValue                     @"DefaultValue"
+#define kIASKDisplaySortedByTitle             @"DisplaySortedByTitle"
 #define kIASKMinimumValue                     @"MinimumValue"
 #define kIASKMaximumValue                     @"MaximumValue"
 #define kIASKTrueValue                        @"TrueValue"

--- a/InAppSettingsKit/Models/IASKSettingsReader.m
+++ b/InAppSettingsKit/Models/IASKSettingsReader.m
@@ -127,6 +127,7 @@
     for (NSDictionary *specifierDictionary in preferenceSpecifiers) {
         IASKSpecifier *newSpecifier = [[IASKSpecifier alloc] initWithSpecifier:specifierDictionary];
         newSpecifier.settingsReader = self;
+        [newSpecifier sortIfNeeded];
 
         if ([self.hiddenKeys containsObject:newSpecifier.key]) {
             continue;
@@ -144,6 +145,7 @@
                     IASKSpecifier *valueSpecifier =
                         [[IASKSpecifier alloc] initWithSpecifier:specifierDictionary radioGroupValue:value];
                     valueSpecifier.settingsReader = self;
+                    [valueSpecifier sortIfNeeded];
                     [newArray addObject:valueSpecifier];
                 }
             }

--- a/InAppSettingsKit/Models/IASKSpecifier.h
+++ b/InAppSettingsKit/Models/IASKSpecifier.h
@@ -29,6 +29,8 @@
 - (id)initWithSpecifier:(NSDictionary *)specifier
         radioGroupValue:(NSString *)radioGroupValue;
 
+- (void)sortIfNeeded;
+
 - (NSString*)localizedObjectForKey:(NSString*)key;
 - (NSString*)title;
 - (NSString*)subtitle;
@@ -49,6 +51,7 @@
 - (NSString*)minimumValueImage;
 - (NSString*)maximumValueImage;
 - (BOOL)isSecure;
+- (BOOL)displaySortedByTitle;
 - (UIKeyboardType)keyboardType;
 - (UITextAutocapitalizationType)autocapitalizationType;
 - (UITextAutocorrectionType)autoCorrectionType;

--- a/InAppSettingsKitSampleApp/Settings.bundle/Root.inApp.plist
+++ b/InAppSettingsKitSampleApp/Settings.bundle/Root.inApp.plist
@@ -65,6 +65,8 @@
 				<string>9</string>
 				<string>10</string>
 			</array>
+			<key>DisplaySortedByTitle</key>
+			<true/>
 		</dict>
 		<dict>
 			<key>Title</key>

--- a/InAppSettingsKitSampleApp/Settings.bundle/Root.plist
+++ b/InAppSettingsKitSampleApp/Settings.bundle/Root.plist
@@ -101,6 +101,8 @@
 			<string>mulValue</string>
 			<key>DefaultValue</key>
 			<integer>0</integer>
+			<key>DisplaySortedByTitle</key>
+			<true/>
 		</dict>
 		<dict>
 			<key>Type</key>

--- a/InAppSettingsKitSampleApp/Settings.bundle/Root~ipad.inApp.plist
+++ b/InAppSettingsKitSampleApp/Settings.bundle/Root~ipad.inApp.plist
@@ -65,6 +65,8 @@
 				<string>9</string>
 				<string>10</string>
 			</array>
+			<key>DisplaySortedByTitle</key>
+			<true/>
 		</dict>
 		<dict>
 			<key>Title</key>

--- a/InAppSettingsKitSampleApp/Settings.bundle/Root~ipad.plist
+++ b/InAppSettingsKitSampleApp/Settings.bundle/Root~ipad.plist
@@ -93,6 +93,8 @@
 			<string>mulValue</string>
 			<key>DefaultValue</key>
 			<integer>0</integer>
+			<key>DisplaySortedByTitle</key>
+			<true/>
 		</dict>
 		<dict>
 			<key>Type</key>

--- a/InAppSettingsKitSampleApp/Settings.bundle/Root~iphone.inApp.plist
+++ b/InAppSettingsKitSampleApp/Settings.bundle/Root~iphone.inApp.plist
@@ -65,6 +65,8 @@
 				<string>9</string>
 				<string>10</string>
 			</array>
+			<key>DisplaySortedByTitle</key>
+			<true/>
 		</dict>
 		<dict>
 			<key>Title</key>

--- a/InAppSettingsKitSampleApp/Settings.bundle/Root~iphone.plist
+++ b/InAppSettingsKitSampleApp/Settings.bundle/Root~iphone.plist
@@ -93,6 +93,8 @@
 			<string>mulValue</string>
 			<key>DefaultValue</key>
 			<integer>0</integer>
+			<key>DisplaySortedByTitle</key>
+			<true/>
 		</dict>
 		<dict>
 			<key>Type</key>

--- a/InAppSettingsKitTests/IASKSettingsReaderTests.m
+++ b/InAppSettingsKitTests/IASKSettingsReaderTests.m
@@ -9,6 +9,7 @@
 #import <XCTest/XCTest.h>
 #import <UIKit/UIKit.h>
 #import "IASKSettingsReader.h"
+#import "IASKSpecifier.h"
 
 @interface IASKSettingsReaderTests : XCTestCase {
   NSString* settingsBundlePath;
@@ -69,6 +70,14 @@
   XCTAssertEqualObjects([reader.settingsDictionary objectForKey:@"Title"],
                        @"ADVANCED_TITLE",
                        @"Advanced file not found");
+}
+
+- (void) testSettingsReaderSortsByLocalizedKey {
+  IASKSettingsReader* reader = [[IASKSettingsReader alloc] initWithSettingsFileNamed:@"Root"
+                                                                   applicationBundle:[NSBundle bundleForClass:[self class]]];
+    IASKSpecifier *multiSpecifier = [reader specifierForKey:@"mulValue"];
+    XCTAssertTrue([multiSpecifier displaySortedByTitle]);
+    XCTAssertEqualObjects([multiSpecifier multipleValues], (@[@"0", @"6", @"1", @"4", @"5", @"7", @"3", @"9", @"8", @"10", @"2"]));
 }
 
 #pragma mark - parsing

--- a/InAppSettingsKitTests/IASKSettingsReaderTests.m
+++ b/InAppSettingsKitTests/IASKSettingsReaderTests.m
@@ -80,6 +80,11 @@
     XCTAssertEqualObjects([multiSpecifier multipleValues], (@[@"0", @"6", @"1", @"4", @"5", @"7", @"3", @"9", @"8", @"10", @"2"]));
 }
 
+- (void) testSettingsReaderFailsToSortMalformedMultiValueEntries {
+    XCTAssertThrows([[IASKSettingsReader alloc] initWithSettingsFileNamed:@"Malformed"
+                                                        applicationBundle:[NSBundle bundleForClass:[self class]]]);
+}
+
 #pragma mark - parsing
 - (void) testSettingsReaderInterpretsAdvancedSettings {
   IASKSettingsReader* reader = [[IASKSettingsReader alloc] initWithSettingsFileNamed:@"Advanced"

--- a/InAppSettingsKitTests/Settings.bundle/Malformed.plist
+++ b/InAppSettingsKitTests/Settings.bundle/Malformed.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Title</key>
+	<string>WhereTo</string>
+	<key>StringsTable</key>
+	<string>Root</string>
+	<key>PreferenceSpecifiers</key>
+	<array>
+		<dict>
+			<key>Values</key>
+			<array>
+				<real>0</real>
+			</array>
+			<key>Titles</key>
+			<array>
+				<string>VALUE_PRESENT</string>
+				<string>VALUE_ABSENT</string>
+			</array>
+			<key>Type</key>
+			<string>PSMultiValueSpecifier</string>
+			<key>Title</key>
+			<string>MUL_VAL</string>
+			<key>Key</key>
+			<string>mulValue</string>
+			<key>DefaultValue</key>
+			<integer>0</integer>
+			<key>DisplaySortedByTitle</key>
+			<true/>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/InAppSettingsKitTests/Settings.bundle/Root.inApp.plist
+++ b/InAppSettingsKitTests/Settings.bundle/Root.inApp.plist
@@ -65,6 +65,8 @@
 				<string>9</string>
 				<string>10</string>
 			</array>
+			<key>DisplaySortedByTitle</key>
+			<true/>
 		</dict>
 		<dict>
 			<key>Title</key>

--- a/InAppSettingsKitTests/Settings.bundle/Root.plist
+++ b/InAppSettingsKitTests/Settings.bundle/Root.plist
@@ -101,6 +101,8 @@
 			<string>mulValue</string>
 			<key>DefaultValue</key>
 			<integer>0</integer>
+			<key>DisplaySortedByTitle</key>
+			<true/>
 		</dict>
 		<dict>
 			<key>Type</key>

--- a/InAppSettingsKitTests/Settings.bundle/Root~ipad.inApp.plist
+++ b/InAppSettingsKitTests/Settings.bundle/Root~ipad.inApp.plist
@@ -65,6 +65,8 @@
 				<string>9</string>
 				<string>10</string>
 			</array>
+			<key>DisplaySortedByTitle</key>
+			<true/>
 		</dict>
 		<dict>
 			<key>Title</key>

--- a/InAppSettingsKitTests/Settings.bundle/Root~ipad.plist
+++ b/InAppSettingsKitTests/Settings.bundle/Root~ipad.plist
@@ -93,6 +93,8 @@
 			<string>mulValue</string>
 			<key>DefaultValue</key>
 			<integer>0</integer>
+			<key>DisplaySortedByTitle</key>
+			<true/>
 		</dict>
 		<dict>
 			<key>Type</key>

--- a/InAppSettingsKitTests/Settings.bundle/Root~iphone.inApp.plist
+++ b/InAppSettingsKitTests/Settings.bundle/Root~iphone.inApp.plist
@@ -65,6 +65,8 @@
 				<string>9</string>
 				<string>10</string>
 			</array>
+			<key>DisplaySortedByTitle</key>
+			<true/>
 		</dict>
 		<dict>
 			<key>Title</key>

--- a/InAppSettingsKitTests/Settings.bundle/Root~iphone.plist
+++ b/InAppSettingsKitTests/Settings.bundle/Root~iphone.plist
@@ -93,6 +93,8 @@
 			<string>mulValue</string>
 			<key>DefaultValue</key>
 			<integer>0</integer>
+			<key>DisplaySortedByTitle</key>
+			<true/>
 		</dict>
 		<dict>
 			<key>Type</key>


### PR DESCRIPTION
According to Apple's documentation[1], `DisplaySortedByTitle` changes the
sort order based on the localized sort order of the Titles array.

This commit makes the behavior between IASK and the Settings app more
consistent in this respect.

[1] : https://developer.apple.com/library/ios/documentation/PreferenceSettings/Conceptual/SettingsApplicationSchemaReference/Articles/PSMultiValueSpecifier.html

:octocat: 