### PR TITLE
Add support for UISplitViewController

### DIFF
--- a/InAppSettingsKit.xcodeproj/project.pbxproj
+++ b/InAppSettingsKit.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		1AA106821916565D4D6221F9 /* IASKMultipleValueSelection.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AA1013C46B6050E24DEBCE2 /* IASKMultipleValueSelection.h */; };
 		1AA1073290B7DC27EB0C6A70 /* IASKMultipleValueSelection.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AA10C9888067F44636DBF0D /* IASKMultipleValueSelection.m */; };
+		1E3694581B94F62A000511FA /* IASKAppSettingsSplitViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E3694561B94F62A000511FA /* IASKAppSettingsSplitViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1E3694591B94F62A000511FA /* IASKAppSettingsSplitViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E3694571B94F62A000511FA /* IASKAppSettingsSplitViewController.m */; };
 		AA627D2819F67B7C0079AAE8 /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA627D2719F67B7C0079AAE8 /* MessageUI.framework */; };
 		AA627D2919F67B8E0079AAE8 /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA627D2719F67B7C0079AAE8 /* MessageUI.framework */; };
 		AA627D3B19F695F30079AAE8 /* IASKLocalizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = AA627D2B19F695F30079AAE8 /* IASKLocalizable.strings */; };
@@ -95,6 +97,8 @@
 /* Begin PBXFileReference section */
 		1AA1013C46B6050E24DEBCE2 /* IASKMultipleValueSelection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IASKMultipleValueSelection.h; sourceTree = "<group>"; };
 		1AA10C9888067F44636DBF0D /* IASKMultipleValueSelection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IASKMultipleValueSelection.m; sourceTree = "<group>"; };
+		1E3694561B94F62A000511FA /* IASKAppSettingsSplitViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IASKAppSettingsSplitViewController.h; sourceTree = "<group>"; };
+		1E3694571B94F62A000511FA /* IASKAppSettingsSplitViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IASKAppSettingsSplitViewController.m; sourceTree = "<group>"; };
 		AA627D2719F67B7C0079AAE8 /* MessageUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MessageUI.framework; path = System/Library/Frameworks/MessageUI.framework; sourceTree = SDKROOT; };
 		AA627D2C19F695F30079AAE8 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/IASKLocalizable.strings; sourceTree = "<group>"; };
 		AA627D2D19F695F30079AAE8 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/IASKLocalizable.strings; sourceTree = "<group>"; };
@@ -310,6 +314,8 @@
 				E42ADAC71682036500295D85 /* IASKAppSettingsWebViewController.m */,
 				1AA10C9888067F44636DBF0D /* IASKMultipleValueSelection.m */,
 				1AA1013C46B6050E24DEBCE2 /* IASKMultipleValueSelection.h */,
+				1E3694561B94F62A000511FA /* IASKAppSettingsSplitViewController.h */,
+				1E3694571B94F62A000511FA /* IASKAppSettingsSplitViewController.m */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -456,6 +462,7 @@
 				E401BD4916820A2D00EAF534 /* IASKTextField.h in Headers */,
 				E401BD4B16820BBA00EAF534 /* IASKViewController.h in Headers */,
 				1AA106821916565D4D6221F9 /* IASKMultipleValueSelection.h in Headers */,
+				1E3694581B94F62A000511FA /* IASKAppSettingsSplitViewController.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -641,6 +648,7 @@
 				E4EDC5A916820D9500BD3CA9 /* IASKSwitch.m in Sources */,
 				E4EDC5AA16820D9500BD3CA9 /* IASKTextField.m in Sources */,
 				1AA1073290B7DC27EB0C6A70 /* IASKMultipleValueSelection.m in Sources */,
+				1E3694591B94F62A000511FA /* IASKAppSettingsSplitViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/InAppSettingsKit/Controllers/IASKAppSettingsSplitViewController.h
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsSplitViewController.h
@@ -18,7 +18,7 @@
 
 #import "IASKAppSettingsViewController.h"
 
-@interface IASKAppSettingsSplitViewController : UISplitViewController<IASKSettingsMasterViewControllerDelegate>
+@interface IASKAppSettingsSplitViewController : UISplitViewController<UISplitViewControllerDelegate, IASKSettingsMasterViewControllerDelegate>
 
 - (instancetype)initWithSettingsViewController:(IASKAppSettingsViewController *)settingsViewController;
 

--- a/InAppSettingsKit/Controllers/IASKAppSettingsSplitViewController.h
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsSplitViewController.h
@@ -1,0 +1,25 @@
+//
+//  IASKAppSettingsSplitViewController.h
+//  http://www.inappsettingskit.com
+//
+//  Copyright (c) 2009:
+//  Luc Vandal, Edovia Inc., http://www.edovia.com
+//  Ortwin Gentz, FutureTap GmbH, http://www.futuretap.com
+//  All rights reserved.
+//
+//  It is appreciated but not required that you give credit to Luc Vandal and Ortwin Gentz,
+//  as the original authors of this code. You can give credit in a blog post, a tweet or on
+//  a info page of your app. Also, the original authors appreciate letting them know if you use this code.
+//
+//  This code is licensed under the BSD license that is available at: http://www.opensource.org/licenses/bsd-license.php
+//
+
+#import <UIKit/UIKit.h>
+
+#import "IASKAppSettingsViewController.h"
+
+@interface IASKAppSettingsSplitViewController : UISplitViewController<IASKSettingsMasterViewControllerDelegate>
+
+- (instancetype)initWithSettingsViewController:(IASKAppSettingsViewController *)settingsViewController;
+
+@end

--- a/InAppSettingsKit/Controllers/IASKAppSettingsSplitViewController.m
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsSplitViewController.m
@@ -36,7 +36,7 @@
 @end
 
 @implementation IASKAppSettingsSplitViewController {
-  IASKAppSettingsViewController *_settingsViewController;
+  IASKAppSettingsViewController *_masterSettingsViewController;
   UINavigationController *_masterNavigationViewController;
   UINavigationController *_detailNavigationViewController;
 }
@@ -49,7 +49,7 @@
 - (instancetype)initWithSettingsViewController:(IASKAppSettingsViewController *)settingsViewController {
   self = [super init];
   if (self) {
-    _settingsViewController = settingsViewController;
+    _masterSettingsViewController = settingsViewController;
   }
   return self;
 }
@@ -57,7 +57,7 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  _masterNavigationViewController = [[UINavigationController alloc] initWithRootViewController:_settingsViewController];
+  _masterNavigationViewController = [[UINavigationController alloc] initWithRootViewController:_masterSettingsViewController];
 
   // Show both master & detail view in portrait mode on iPad
   if ([self respondsToSelector:@selector(preferredDisplayMode)]) {            // >= iOS 8
@@ -66,10 +66,20 @@
   } else {                                                                    // < iOS 8
     _detailNavigationViewController = [[IASKAppSettingsDetailNavigationController alloc] init];
     self.delegate = (IASKAppSettingsDetailNavigationController *)_detailNavigationViewController;
-    _settingsViewController.masterViewControllerDelegate = self;
+    _masterSettingsViewController.masterViewControllerDelegate = self;
   }
 
   self.viewControllers = @[_masterNavigationViewController, _detailNavigationViewController];
+  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(settingDidChange:) name:kIASKAppSettingChanged object:nil];
+}
+
+- (void)dealloc {
+  [[NSNotificationCenter defaultCenter] removeObserver:self name:kIASKAppSettingChanged object:nil];
+}
+
+#pragma mark kIASKAppSettingChanged notification
+- (void)settingDidChange:(NSNotification*)notification {
+  [_masterSettingsViewController.tableView reloadData];
 }
 
 #pragma mark - IASKSettingsMasterViewDelegate - required for pre iOS 8

--- a/InAppSettingsKit/Controllers/IASKAppSettingsSplitViewController.m
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsSplitViewController.m
@@ -1,0 +1,81 @@
+//
+//  IASKAppSettingsSplitViewController.m
+//  http://www.inappsettingskit.com
+//
+//  Copyright (c) 2009:
+//  Luc Vandal, Edovia Inc., http://www.edovia.com
+//  Ortwin Gentz, FutureTap GmbH, http://www.futuretap.com
+//  All rights reserved.
+//
+//  It is appreciated but not required that you give credit to Luc Vandal and Ortwin Gentz,
+//  as the original authors of this code. You can give credit in a blog post, a tweet or on
+//  a info page of your app. Also, the original authors appreciate letting them know if you use this code.
+//
+//  This code is licensed under the BSD license that is available at: http://www.opensource.org/licenses/bsd-license.php
+//
+
+#import "IASKAppSettingsSplitViewController.h"
+
+#import "IASKSettingsReader.h"
+
+// Custom UINavigationController to be used in the detail view controller in order to support iOS < 8
+@interface IASKAppSettingsDetailNavigationController : UINavigationController<UISplitViewControllerDelegate>
+
+@end
+
+@implementation IASKAppSettingsDetailNavigationController
+
+- (BOOL)splitViewController:(UISplitViewController *)svc shouldHideViewController:(UIViewController *)vc inOrientation:(UIInterfaceOrientation)orientation{
+  return NO;
+}
+
+@end
+
+@interface IASKAppSettingsSplitViewController ()
+
+@end
+
+@implementation IASKAppSettingsSplitViewController {
+  IASKAppSettingsViewController *_settingsViewController;
+  UINavigationController *_masterNavigationViewController;
+  UINavigationController *_detailNavigationViewController;
+}
+
+- (instancetype)init
+{
+  return [self initWithSettingsViewController:[[IASKAppSettingsViewController alloc] init]];
+}
+
+- (instancetype)initWithSettingsViewController:(IASKAppSettingsViewController *)settingsViewController {
+  self = [super init];
+  if (self) {
+    _settingsViewController = settingsViewController;
+  }
+  return self;
+}
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+
+  _masterNavigationViewController = [[UINavigationController alloc] initWithRootViewController:_settingsViewController];
+
+  // Show both master & detail view in portrait mode on iPad
+  if ([self respondsToSelector:@selector(preferredDisplayMode)]) {            // >= iOS 8
+    _detailNavigationViewController = [[UINavigationController alloc] init];
+    self.preferredDisplayMode = UISplitViewControllerDisplayModeAllVisible;
+  } else {                                                                    // < iOS 8
+    _detailNavigationViewController = [[IASKAppSettingsDetailNavigationController alloc] init];
+    self.delegate = (IASKAppSettingsDetailNavigationController *)_detailNavigationViewController;
+    _settingsViewController.masterViewControllerDelegate = self;
+  }
+
+  self.viewControllers = @[_masterNavigationViewController, _detailNavigationViewController];
+}
+
+#pragma mark - IASKSettingsMasterViewDelegate - required for pre iOS 8
+
+- (void)showDetailViewController:(UIViewController *)viewController {
+  _detailNavigationViewController.viewControllers = @[viewController];
+}
+
+@end

--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.h
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.h
@@ -28,6 +28,11 @@
 - (void)settingsViewControllerDidEnd:(IASKAppSettingsViewController*)sender;
 
 @optional
+
+// A view controller that should be displayed as the initial details view controller when the settings are displayed
+// in a UISplitViewController
+- (UIViewController *)initialDetailViewControllerForSettingsViewController:(IASKAppSettingsViewController *)sender;
+
 #pragma mark - UITableView header customization
 - (CGFloat) settingsViewController:(id<IASKViewController>)settingsViewController
                          tableView:(UITableView *)tableView

--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.h
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.h
@@ -58,10 +58,18 @@
 - (void)settingsViewController:(IASKAppSettingsViewController*)sender tableView:(UITableView *)tableView didSelectCustomViewSpecifier:(IASKSpecifier*)specifier;
 @end
 
+#pragma mark - delegate for when this view controller is a master view controller in a UISplitViewController on pre iOS 8 devices
+@protocol IASKSettingsMasterViewControllerDelegate
 
+- (void)showDetailViewController:(UIViewController *)viewController;
+
+@end
+
+#pragma mark - IASKAppSettingsViewController
 @interface IASKAppSettingsViewController : UITableViewController <IASKViewController, UITextFieldDelegate, MFMailComposeViewControllerDelegate>
 
 @property (nonatomic, assign) IBOutlet id delegate;
+@property (nonatomic, assign) IBOutlet id<IASKSettingsMasterViewControllerDelegate> masterViewControllerDelegate;
 @property (nonatomic, copy) NSString *file;
 @property (nonatomic, assign) BOOL showCreditsFooter;
 @property (nonatomic, assign) IBInspectable BOOL showDoneButton;

--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.h
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.h
@@ -29,8 +29,15 @@
 
 @optional
 
+// The initial index path that should be selected when the settings are displayed in a UISplitViewController
+// If initialSelectedIndexPathForSettingsViewController: is also implemented, this method will be preferred.
+- (NSIndexPath *)initialSelectedIndexPathForSettingsViewController:(IASKAppSettingsViewController *)sender;
+
 // A view controller that should be displayed as the initial details view controller when the settings are displayed
-// in a UISplitViewController
+// in a UISplitViewController. As opposed to initialSelectedIndexPathForSettingsViewController: this method enables
+// displaying an arbitrary view controller as the details view controller. The downside is that no item in the master
+// view controller will appear selected. If both methods are implemented, initialSelectedIndexPathForSettingsViewController:
+// will be preferred.
 - (UIViewController *)initialDetailViewControllerForSettingsViewController:(IASKAppSettingsViewController *)sender;
 
 #pragma mark - UITableView header customization

--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -221,11 +221,17 @@ CGRect IASKCGRectSwap(CGRect rect);
     if (
         [self isMasterViewController] &&
         self.splitViewController.viewControllers.count == 2 &&
-        ((UINavigationController *)self.splitViewController.viewControllers[1]).viewControllers.count == 0 &&
-        [self.delegate respondsToSelector:@selector(initialDetailViewControllerForSettingsViewController:)]
-        )
-    {
-        [self pushViewController:[self.delegate initialDetailViewControllerForSettingsViewController:self]];
+        ((UINavigationController *)self.splitViewController.viewControllers[1]).viewControllers.count == 0
+        ) {
+        if ([self.delegate respondsToSelector:@selector(initialSelectedIndexPathForSettingsViewController:)]) {
+            NSIndexPath *indexPath = [self.delegate initialSelectedIndexPathForSettingsViewController:self];
+            [self.tableView selectRowAtIndexPath:indexPath animated:YES scrollPosition:UITableViewScrollPositionNone];
+            [self.tableView scrollToRowAtIndexPath:indexPath atScrollPosition:UITableViewScrollPositionNone animated:YES];
+            [self.delegate tableView:self.tableView didSelectRowAtIndexPath:indexPath];
+//            [[NSNotificationCenter defaultCenter] postNotificationName:UITableViewSelectionDidChangeNotification object:self.tableView];
+        } else if ([self.delegate respondsToSelector:@selector(initialDetailViewControllerForSettingsViewController:)]) {
+            [self pushViewController:[self.delegate initialDetailViewControllerForSettingsViewController:self]];
+        }
     }
 }
 

--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -843,7 +843,10 @@ CGRect IASKCGRectSwap(CGRect rect);
 - (void)pushViewController:(UIViewController *)viewController {
     if ([self isMasterViewController]) {
         if ([self respondsToSelector:@selector(showDetailViewController:sender:)]) {    // iOS 8+
-            [self showDetailViewController:[[UINavigationController alloc] initWithRootViewController:viewController] sender:nil];
+            UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:viewController];
+            IASK_IF_IOS7_OR_GREATER(navigationController.navigationBar.tintColor = self.navigationController.navigationBar.tintColor;);
+            navigationController.navigationBar.translucent = self.navigationController.navigationBar.translucent;
+            [self showDetailViewController:navigationController sender:nil];
         } else {                                                                        // < iOS 8
             [self.masterViewControllerDelegate showDetailViewController:viewController];
         }

--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -209,7 +209,24 @@ CGRect IASKCGRectSwap(CGRect rect);
 		[dc addObserver:self selector:@selector(didChangeSettingViaIASK:) name:kIASKAppSettingChanged object:nil];
 		[self userDefaultsDidChange]; // force update in case of changes while we were hidden
 	}
+
+  [self setInitialDetailViewControllerIfNeeded];
+
 	[super viewWillAppear:animated];
+}
+
+// Set an initial details view controller only if the details view controller is currently being displayed,
+// the split view controller isn't collapsed (iOS 8+) & the delegate provides one
+- (void)setInitialDetailViewControllerIfNeeded {
+    if (
+        [self isMasterViewController] &&
+        self.splitViewController.viewControllers.count == 2 &&
+        ((UINavigationController *)self.splitViewController.viewControllers[1]).viewControllers.count == 0 &&
+        [self.delegate respondsToSelector:@selector(initialDetailViewControllerForSettingsViewController:)]
+        )
+    {
+        [self pushViewController:[self.delegate initialDetailViewControllerForSettingsViewController:self]];
+    }
 }
 
 - (CGSize)contentSizeForViewInPopover {
@@ -844,7 +861,7 @@ CGRect IASKCGRectSwap(CGRect rect);
     if ([self isMasterViewController]) {
         if ([self respondsToSelector:@selector(showDetailViewController:sender:)]) {    // iOS 8+
             UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:viewController];
-            IASK_IF_IOS7_OR_GREATER(navigationController.navigationBar.tintColor = self.navigationController.navigationBar.tintColor;);
+            navigationController.navigationBar.tintColor = self.navigationController.navigationBar.tintColor;
             navigationController.navigationBar.translucent = self.navigationController.navigationBar.translucent;
             [self showDetailViewController:navigationController sender:nil];
         } else {                                                                        // < iOS 8

--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -681,7 +681,7 @@ CGRect IASKCGRectSwap(CGRect rect);
         targetViewController.settingsStore = self.settingsStore;
 		IASK_IF_IOS7_OR_GREATER(targetViewController.view.tintColor = self.view.tintColor;)
         _currentChildViewController = targetViewController;
-        [[self navigationController] pushViewController:targetViewController animated:YES];
+        [self pushViewController:targetViewController];
         
     } else if ([[specifier type] isEqualToString:kIASKPSTextFieldSpecifier]) {
         IASKPSTextFieldSpecifierViewCell *textFieldCell = (id)[tableView cellForRowAtIndexPath:indexPath];
@@ -694,7 +694,7 @@ CGRect IASKCGRectSwap(CGRect rect);
 			UIStoryboard *storyBoard = [UIStoryboard storyboardWithName:storyBoardFileFromSpecifier bundle:nil];
 			UIViewController * vc = [storyBoard instantiateViewControllerWithIdentifier:[specifier viewControllerStoryBoardID]];
 			IASK_IF_IOS7_OR_GREATER(vc.view.tintColor = self.view.tintColor;)
-            [self.navigationController pushViewController:vc animated:YES];
+            [self pushViewController:vc];
 			return;
 		}
         
@@ -716,7 +716,7 @@ CGRect IASKCGRectSwap(CGRect rect);
                 [vc performSelector:@selector(setSettingsStore:) withObject:self.settingsStore];
             }
 			IASK_IF_IOS7_OR_GREATER(vc.view.tintColor = self.view.tintColor;)
-            [self.navigationController pushViewController:vc animated:YES];
+            [self pushViewController:vc];
             return;
         }
         
@@ -740,7 +740,7 @@ CGRect IASKCGRectSwap(CGRect rect);
         
         _reloadDisabled = NO;
 		
-        [[self navigationController] pushViewController:targetViewController animated:YES];
+        [self pushViewController:targetViewController];
         
     } else if ([[specifier type] isEqualToString:kIASKOpenURLSpecifier]) {
         [tableView deselectRowAtIndexPath:indexPath animated:YES];
@@ -840,6 +840,33 @@ CGRect IASKCGRectSwap(CGRect rect);
     }
 }
 
+- (void)pushViewController:(UIViewController *)viewController {
+    if ([self isMasterViewController]) {
+        if ([self respondsToSelector:@selector(showDetailViewController:sender:)]) {    // iOS 8+
+            [self showDetailViewController:[[UINavigationController alloc] initWithRootViewController:viewController] sender:nil];
+        } else {                                                                        // < iOS 8
+            [self.masterViewControllerDelegate showDetailViewController:viewController];
+        }
+    } else {
+        [self.navigationController pushViewController:viewController animated:YES];
+    }
+}
+
+// Checks if self is inside the view controller heirarchy of a master view controller inside a UISplitViewController
+- (BOOL)isMasterViewController {
+    if (self.splitViewController) {
+        UIViewController *masterViewController = self.splitViewController.viewControllers[0];
+        UIViewController *parentViewController = self.parentViewController;
+        while (parentViewController != nil) {
+            if (parentViewController == masterViewController) {
+                return YES;
+            }
+            parentViewController = parentViewController.parentViewController;
+        }
+    }
+
+    return NO;
+}
 
 #pragma mark -
 #pragma mark MFMailComposeViewControllerDelegate Function

--- a/InAppSettingsKitSampleApp/Base.lproj/MainWindow.xib
+++ b/InAppSettingsKitSampleApp/Base.lproj/MainWindow.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6250" systemVersion="14B25" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7706" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6244"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="UIApplication">
@@ -28,7 +28,7 @@
         </window>
         <tabBarController id="47">
             <nil key="simulatedBottomBarMetrics"/>
-            <tabBar key="tabBar" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" selectedItem="57" id="48">
+            <tabBar key="tabBar" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="48">
                 <rect key="frame" x="0.0" y="431" width="320" height="49"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
             </tabBar>
@@ -42,36 +42,9 @@
                         <viewController id="23" customClass="MainViewController">
                             <navigationItem key="navigationItem" title="InAppSettingKit Demo" id="25"/>
                             <connections>
-                                <outlet property="tabAppSettingsViewController" destination="67" id="84"/>
                                 <outlet property="view" destination="29" id="32"/>
                             </connections>
                         </viewController>
-                    </viewControllers>
-                </navigationController>
-                <navigationController id="56">
-                    <extendedEdge key="edgesForExtendedLayout"/>
-                    <tabBarItem key="tabBarItem" title="Settings" image="20-gear2.png" id="57"/>
-                    <toolbarItems/>
-                    <navigationBar key="navigationBar" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" id="60">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </navigationBar>
-                    <viewControllers>
-                        <tableViewController id="67" customClass="IASKAppSettingsViewController">
-                            <tableView key="view" opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="none" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" id="68">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
-                                <connections>
-                                    <outlet property="dataSource" destination="67" id="70"/>
-                                    <outlet property="delegate" destination="67" id="69"/>
-                                </connections>
-                            </tableView>
-                            <navigationItem key="navigationItem" title="Item" id="71"/>
-                            <connections>
-                                <outlet property="delegate" destination="23" id="79"/>
-                            </connections>
-                        </tableViewController>
                     </viewControllers>
                 </navigationController>
             </viewControllers>
@@ -108,9 +81,6 @@
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
         </view>
     </objects>
-    <resources>
-        <image name="20-gear2.png" width="26" height="28"/>
-    </resources>
     <simulatedMetricsContainer key="defaultSimulatedMetrics">
         <simulatedStatusBarMetrics key="statusBar"/>
         <simulatedOrientationMetrics key="orientation"/>

--- a/InAppSettingsKitSampleApp/Classes/MainViewController.m
+++ b/InAppSettingsKitSampleApp/Classes/MainViewController.m
@@ -103,6 +103,20 @@
 	self.currentPopoverController = popover;
 }
 
+- (UIViewController *)initialDetailViewControllerForSettingsViewController:(IASKAppSettingsViewController *)sender {
+  IASKAppSettingsViewController *targetViewController = [[[sender class] alloc] init];
+  targetViewController.showDoneButton = NO;
+  targetViewController.showCreditsFooter = NO; // Does not reload the tableview (but next setters do it)
+  targetViewController.delegate = sender.delegate;
+  targetViewController.settingsStore = sender.settingsStore;
+  targetViewController.file = @"Complete";
+  targetViewController.hiddenKeys = sender.hiddenKeys;
+  targetViewController.title = @"Complete List";
+  IASK_IF_IOS7_OR_GREATER(targetViewController.view.tintColor = sender.view.tintColor;)
+
+  return targetViewController;
+}
+
 - (void)awakeFromNib {
 	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(settingDidChange:) name:kIASKAppSettingChanged object:nil];
 	BOOL enabled = [[NSUserDefaults standardUserDefaults] boolForKey:@"AutoConnect"];
@@ -116,6 +130,7 @@
   NSMutableArray *viewControllers = [self.tabBarController.viewControllers mutableCopy];
   IASKAppSettingsViewController *settingsViewController = [[IASKAppSettingsViewController alloc] init];
   settingsViewController.showDoneButton = NO;
+  settingsViewController.delegate = self;
 
   UIViewController *settingsTabBarViewController;
   BOOL ios8 = NO;

--- a/InAppSettingsKitSampleApp/InAppSettingsKitSampleApp-Info.plist
+++ b/InAppSettingsKitSampleApp/InAppSettingsKitSampleApp-Info.plist
@@ -33,6 +33,16 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 </dict>
 </plist>

--- a/README.md
+++ b/README.md
@@ -54,14 +54,18 @@ Use the static library project to include InAppSettingsKit. To see an example on
 * use IASK by importing it via #import "InAppSettingsKit/..."
 * for Archive builds there's a minor annoyance: To make those work, you'll need to add `$(OBJROOT)/UninstalledProducts/include` to the `HEADER_SEARCH_PATHS`
 
-Then you can display the InAppSettingsKit view controller using a navigation push, as a modal view controller or in a separate tab of a TabBar based application. The sample app demonstrates all three ways to integrate InAppSettingsKit. 
+Then you can display the InAppSettingsKit view controller using a navigation push, as a modal view controller, a popover (on iPad) or in a separate tab of a TabBar based application. The sample app demonstrates all four ways to integrate InAppSettingsKit.
+
+InAppSettingsKit supports split view on all devices, OS versions & orientations. Setting this up correctly can be a bit tricky, especially as the behavior of UISplitViewController is different on pre iOS 8 devices. To make this easier, InAppSettingsKit includes a custom subclass of UISplitViewController which can be used (see the sample app for usage examples).
+
+Note that a UISplitViewController can't be pushed onto a UINavigationController or be used as a popover so in these cases we use the InAppSettingsViewController directly. Pre iOS 8 a UISplitViewController can't be displayed modally but there's a workaround for this which can be found in the sample app.
 
 App Integration
 ===============
 
 Depending on your project it might be needed to make some changes in the startup code of your app. Your app has to be able to reconfigure itself at runtime if the settings are changed by the user. This could be done in a `-reconfigure` method that is being called from `-applicationDidFinishLaunching` as well as in the delegate method `-settingsViewControllerDidEnd:` of `IASKAppSettingsViewController`.
 
-You may need to make two changes to your project to get it to compile: 1) Add `MessageUI.framework` and 2) enable ARC for the IASK files. Both changes can be made by finding your target and navigating to the Build Phases tab. 
+You may need to make two changes to your project to get it to compile: 1) Add `MessageUI.framework` and 2) enable ARC for the IASK files. Both changes can be made by finding your target and navigating to the Build Phases tab.
 
 `MessageUI.framework` is needed for `MFMailComposeViewController` and can be added in the "Link Binary With Libraries" Section. Use the + icon.
 


### PR DESCRIPTION
This pull request adds support for UISplitViewController on all devices, OS versions & orientations. It supports size classes directly so that on an iPad the settings are displayed with a split view, on iPhone as a standard tableview (collapsed split view) and on the iPhone 6+ as a tableview in portrait (compact) and split in landscape (large).
The behavior of UISplitViewController was changed in iOS 8 as it was made available on the iPhone. Therefore, wiring it up correctly to support all configurations is tricky. For this reason I added an IASKAppSettingsSplitViewController and updated the sample app to use it where relevant. For this reason I removed the settings tab from the storyboard and added it in code so that we use the correct view controller depending on the device & os version we're running on. This is intentionally in a separate commit so that we can revert it if you'd like to keep the storyboard example but in that case it won't support split view (as before).

There are some limitations:
* A UISplitViewController can't be displayed modally pre iOS 8 so I used a workaround that adds it to a container view controller - works nicely.
* A UISplitViewController can't be pushed onto a UINavigationController. The previous workaround can be used here as well but the external UINavigationController doesn't play nicely with the ones inside the UISplitViewController so this isn't recommended. Therefore in the sample app I don't use IASKAppSettingsSplitViewController for the push example.

I've added documentation where relevant & updated the readme.

Tested on all of the following configurations in the simulator:
* iPhone 4s, iPhone 5, iPhone 6, iPhone 6+, iPad Air
* iOS 7.1, iOS 8.3 
* Portrait & Landscape
* Tab, Push, Modal, Popover

I don't have all of the above configurations so I tested on a selection of physical devices.

I believe this fix should also support the new split view (side by side apps) on iPads running iOS 9 but I haven't verified this because InAppSettingsKit doesn't compile under Xcode 7. I plan to submit a separate pull request for that after which this can be tested.