### PR TITLE
Fix localization iOS 8+

### DIFF
--- a/InAppSettingsKit/Models/IASKSettingsReader.m
+++ b/InAppSettingsKit/Models/IASKSettingsReader.m
@@ -99,16 +99,17 @@
 }
 
 - (NSArray*)privacySettingsSpecifiers {
-	NSMutableDictionary *dict = [@{kIASKTitle: NSLocalizedStringFromTable(@"Privacy", @"IASKLocalizable", @"iOS 8+ Privacy cell: title"),
+	NSMutableDictionary *dict = [@{kIASKTitle: [[self bundle:NO] localizedStringForKey:@"Privacy" value:@"" table:@"IASKLocalizable"],
 								   kIASKKey: @"IASKPrivacySettingsCellKey",
 								   kIASKType: kIASKOpenURLSpecifier,
 								   kIASKFile: UIApplicationOpenSettingsURLString,
 								   } mutableCopy];
-	NSString *subtitle = NSLocalizedStringWithDefaultValue(@"Open in Settings app", @"IASKLocalizable", [NSBundle mainBundle], @"", @"iOS 8+ Privacy cell: subtitle");
+	NSString *subtitle = [[self bundle:NO] localizedStringForKey:@"Open in Settings app" value:@"" table:@"IASKLocalizable"];
+
 	if (subtitle.length) {
 		dict [kIASKSubtitle] = subtitle;
 	}
-	
+
 	return @[@[[[IASKSpecifier alloc] initWithSpecifier:@{kIASKKey: @"IASKPrivacySettingsHeaderKey", kIASKType: kIASKPSGroupSpecifier}],
 			   [[IASKSpecifier alloc] initWithSpecifier:dict]]];
 }
@@ -257,6 +258,20 @@
 	bundle = [self.applicationBundle pathForResource:bundle ofType:nil];
     file = [file stringByAppendingFormat:@"%@%@", suffix, extension];
     return [bundle stringByAppendingPathComponent:file];
+}
+
+- (NSBundle*)bundle:(BOOL)forceMainBundle {
+	NSURL *inAppSettingsBundlePath = [[NSBundle mainBundle] URLForResource:@"InAppSettingsKit" withExtension:@"bundle"];
+	NSBundle *bundle;
+
+	if (inAppSettingsBundlePath && !forceMainBundle) {
+		// Appirater.bundle will likely only exist when used via CocoaPods
+		bundle = [NSBundle bundleWithURL:inAppSettingsBundlePath];
+	} else {
+		bundle = [NSBundle mainBundle];
+	}
+
+	return bundle;
 }
 
 - (NSString *)locateSettingsFile: (NSString *)file {


### PR DESCRIPTION
Hi,
it seems to be that you have a small Problem with your localization (Privacy-Label).
I fixed it by setting the correct Bundle for the localization Files.

As you can see on the screenshots, the Device is setup on German, also the German localization from the App is working good, but it says "Privacy", instead of "Datenschutz", after changing the Bundle, we will have the correct Translation.

Device: `Simulator iOS 8.2 iPhone 5` (Screenshots)

Before:

![before](https://cloud.githubusercontent.com/assets/3513740/10997436/7015c476-848d-11e5-90c3-79b35aaeb9ed.png)

After:

![after](https://cloud.githubusercontent.com/assets/3513740/10997444/78e5283a-848d-11e5-91d6-85c38e2569f3.png)
