### PR TITLE
Uses NSNumberformatter to translate titles written as numbers.

### DIFF
--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -624,7 +624,7 @@ CGRect IASKCGRectSwap(CGRect rect);
 		cell.accessoryType = (specifier.textAlignment == NSTextAlignmentLeft) ? UITableViewCellAccessoryDisclosureIndicator : UITableViewCellAccessoryNone;
 	} else if ([specifier.type isEqualToString:kIASKButtonSpecifier]) {
 		NSString *value = [self.settingsStore objectForKey:specifier.key];
-		cell.textLabel.text = [value isKindOfClass:[NSString class]] ? [self.settingsReader titleForStringId:value] : specifier.title;
+		cell.textLabel.text = [value isKindOfClass:[NSString class]] ? [self.settingsReader titleForId:value] : specifier.title;
 		cell.detailTextLabel.text = specifier.subtitle;
 		IASK_IF_IOS7_OR_GREATER
 		(if (specifier.textAlignment != NSTextAlignmentLeft) {
@@ -634,7 +634,7 @@ CGRect IASKCGRectSwap(CGRect rect);
 		cell.accessoryType = (specifier.textAlignment == NSTextAlignmentLeft) ? UITableViewCellAccessoryDisclosureIndicator : UITableViewCellAccessoryNone;
 	} else if ([specifier.type isEqualToString:kIASKPSRadioGroupSpecifier]) {
 		NSInteger index = [specifier.multipleValues indexOfObject:specifier.radioGroupValue];
-		cell.textLabel.text = [self.settingsReader titleForStringId:specifier.multipleTitles[index]];
+		cell.textLabel.text = [self.settingsReader titleForId:specifier.multipleTitles[index]];
 		[_selections[indexPath.section] updateSelectionInCell:cell indexPath:indexPath];
 	} else {
 		cell.textLabel.text = specifier.title;

--- a/InAppSettingsKit/Controllers/IASKSpecifierValuesViewController.m
+++ b/InAppSettingsKit/Controllers/IASKSpecifierValuesViewController.m
@@ -113,7 +113,7 @@
     [_selection updateSelectionInCell:cell indexPath:indexPath];
 
     @try {
-		[[cell textLabel] setText:[self.settingsReader titleForStringId:[titles objectAtIndex:indexPath.row]]];
+		[[cell textLabel] setText:[self.settingsReader titleForId:[titles objectAtIndex:indexPath.row]]];
 	}
 	@catch (NSException * e) {}
     return cell;

--- a/InAppSettingsKit/Models/IASKSettingsReader.h
+++ b/InAppSettingsKit/Models/IASKSettingsReader.h
@@ -216,7 +216,7 @@ __VA_ARGS__ \
 - (NSString*)titleForSection:(NSInteger)section;
 - (NSString*)keyForSection:(NSInteger)section;
 - (NSString*)footerTextForSection:(NSInteger)section;
-- (NSString*)titleForStringId:(NSString*)stringId;
+- (NSString*)titleForId:(NSObject*)titleId;
 - (NSString*)pathForImageNamed:(NSString*)image;
 
 ///the main application bundle. most often [NSBundle mainBundle]

--- a/InAppSettingsKit/Models/IASKSettingsReader.m
+++ b/InAppSettingsKit/Models/IASKSettingsReader.m
@@ -222,7 +222,7 @@
 }
 
 - (NSString*)titleForSection:(NSInteger)section {
-    return [self titleForStringId:[self headerSpecifierForSection:section].title];
+    return [self titleForId:[self headerSpecifierForSection:section].title];
 }
 
 - (NSString*)keyForSection:(NSInteger)section {
@@ -230,11 +230,22 @@
 }
 
 - (NSString*)footerTextForSection:(NSInteger)section {
-    return [self titleForStringId:[self headerSpecifierForSection:section].footerText];
+    return [self titleForId:[self headerSpecifierForSection:section].footerText];
 }
 
-- (NSString*)titleForStringId:(NSString*)stringId {
-    return [self.settingsBundle localizedStringForKey:stringId value:stringId table:self.localizationTable];
+- (NSString*)titleForId:(NSObject*)titleId
+{
+	if([titleId isKindOfClass:[NSNumber class]]) {
+		NSNumber* numberTitleId = (NSNumber*)titleId;
+		NSNumberFormatter* formatter = [NSNumberFormatter new];
+		[formatter setNumberStyle:NSNumberFormatterNoStyle];
+		return [formatter stringFromNumber:numberTitleId];
+	}
+	else
+	{
+		NSString* stringTitleId = (NSString*)titleId;
+		return [self.settingsBundle localizedStringForKey:stringTitleId value:stringTitleId table:self.localizationTable];
+	}
 }
 
 - (NSString*)pathForImageNamed:(NSString*)image {

--- a/InAppSettingsKit/Models/IASKSpecifier.m
+++ b/InAppSettingsKit/Models/IASKSpecifier.m
@@ -95,7 +95,7 @@
         static NSString *const valueKey = @"value";
         IASKSettingsReader *strongSettingsReader = self.settingsReader;
         [titles enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
-            NSString *localizedTitle = [strongSettingsReader titleForStringId:obj];
+            NSString *localizedTitle = [strongSettingsReader titleForId:obj];
             [temporaryMappingsForSort addObject:@{titleKey : obj,
                                                   valueKey : values[idx],
                                                   localizedTitleKey : localizedTitle,
@@ -152,7 +152,7 @@
 
 - (NSString*)localizedObjectForKey:(NSString*)key {
 	IASKSettingsReader *settingsReader = self.settingsReader;
-	return [settingsReader titleForStringId:[_specifierDict objectForKey:key]];
+	return [settingsReader titleForId:[_specifierDict objectForKey:key]];
 }
 
 - (NSString*)title {
@@ -226,7 +226,7 @@
 	}
 	@try {
 		IASKSettingsReader *strongSettingsReader = self.settingsReader;
-		return [strongSettingsReader titleForStringId:[titles objectAtIndex:keyIndex]];
+		return [strongSettingsReader titleForId:[titles objectAtIndex:keyIndex]];
 	}
 	@catch (NSException * e) {}
 	return nil;

--- a/InAppSettingsKitTests/IASKSettingsReaderTests.m
+++ b/InAppSettingsKitTests/IASKSettingsReaderTests.m
@@ -80,6 +80,18 @@
     XCTAssertEqualObjects([multiSpecifier multipleValues], (@[@"0", @"6", @"1", @"4", @"5", @"7", @"3", @"9", @"8", @"10", @"2"]));
 }
 
+- (void) testSettingsReaderLocalizedNumberTitles {
+	IASKSettingsReader* reader = [[IASKSettingsReader alloc] initWithSettingsFileNamed:@"Root"
+																   applicationBundle:[NSBundle bundleForClass:[self class]]];
+	IASKSpecifier *multiSpecifier = [reader specifierForKey:@"mulValueWithNumbers"];
+
+	NSNumberFormatter* formatter = [NSNumberFormatter new];
+	[formatter setNumberStyle:NSNumberFormatterNoStyle];
+
+	XCTAssertEqualObjects([multiSpecifier multipleTitles], (@[@(0), @(1), @(2), @(3)]));
+	XCTAssertEqualObjects([multiSpecifier titleForCurrentValue:@(3)], [formatter stringFromNumber:@(3)]);
+}
+
 - (void) testSettingsReaderFailsToSortMalformedMultiValueEntries {
     XCTAssertThrows([[IASKSettingsReader alloc] initWithSettingsFileNamed:@"Malformed"
                                                         applicationBundle:[NSBundle bundleForClass:[self class]]]);

--- a/InAppSettingsKitTests/Settings.bundle/Root.inApp.plist
+++ b/InAppSettingsKitTests/Settings.bundle/Root.inApp.plist
@@ -69,6 +69,30 @@
 			<true/>
 		</dict>
 		<dict>
+			<key>Values</key>
+			<array>
+				<integer>0</integer>
+				<integer>1</integer>
+				<integer>2</integer>
+				<integer>3</integer>
+			</array>
+			<key>Titles</key>
+			<array>
+				<integer>0</integer>
+				<integer>1</integer>
+				<integer>2</integer>
+				<integer>3</integer>
+			</array>
+			<key>Type</key>
+			<string>PSMultiValueSpecifier</string>
+			<key>Title</key>
+			<string>MUL_VAL_WITH_NUMBERS</string>
+			<key>Key</key>
+			<string>mulValueWithNumbers</string>
+			<key>DefaultValue</key>
+			<integer>0</integer>
+		</dict>
+		<dict>
 			<key>Title</key>
 			<string>MUL_VAL_NO_TITLE</string>
 			<key>Type</key>

--- a/InAppSettingsKitTests/Settings.bundle/Root.plist
+++ b/InAppSettingsKitTests/Settings.bundle/Root.plist
@@ -105,6 +105,30 @@
 			<true/>
 		</dict>
 		<dict>
+			<key>Values</key>
+			<array>
+				<integer>0</integer>
+				<integer>1</integer>
+				<integer>2</integer>
+				<integer>3</integer>
+			</array>
+			<key>Titles</key>
+			<array>
+				<integer>0</integer>
+				<integer>1</integer>
+				<integer>2</integer>
+				<integer>3</integer>
+			</array>
+			<key>Type</key>
+			<string>PSMultiValueSpecifier</string>
+			<key>Title</key>
+			<string>MUL_VAL_WITH_NUMBERS</string>
+			<key>Key</key>
+			<string>mulValueWithNumbers</string>
+			<key>DefaultValue</key>
+			<integer>0</integer>
+		</dict>
+		<dict>
 			<key>Type</key>
 			<string>PSGroupSpecifier</string>
 			<key>Title</key>

--- a/InAppSettingsKitTests/Settings.bundle/Root~ipad.inApp.plist
+++ b/InAppSettingsKitTests/Settings.bundle/Root~ipad.inApp.plist
@@ -69,6 +69,30 @@
 			<true/>
 		</dict>
 		<dict>
+			<key>Values</key>
+			<array>
+				<integer>0</integer>
+				<integer>1</integer>
+				<integer>2</integer>
+				<integer>3</integer>
+			</array>
+			<key>Titles</key>
+			<array>
+				<integer>0</integer>
+				<integer>1</integer>
+				<integer>2</integer>
+				<integer>3</integer>
+			</array>
+			<key>Type</key>
+			<string>PSMultiValueSpecifier</string>
+			<key>Title</key>
+			<string>MUL_VAL_WITH_NUMBERS</string>
+			<key>Key</key>
+			<string>mulValueWithNumbers</string>
+			<key>DefaultValue</key>
+			<integer>0</integer>
+		</dict>
+		<dict>
 			<key>Title</key>
 			<string>MUL_VAL_NO_TITLE</string>
 			<key>Type</key>

--- a/InAppSettingsKitTests/Settings.bundle/Root~ipad.plist
+++ b/InAppSettingsKitTests/Settings.bundle/Root~ipad.plist
@@ -97,6 +97,30 @@
 			<true/>
 		</dict>
 		<dict>
+			<key>Values</key>
+			<array>
+				<integer>0</integer>
+				<integer>1</integer>
+				<integer>2</integer>
+				<integer>3</integer>
+			</array>
+			<key>Titles</key>
+			<array>
+				<integer>0</integer>
+				<integer>1</integer>
+				<integer>2</integer>
+				<integer>3</integer>
+			</array>
+			<key>Type</key>
+			<string>PSMultiValueSpecifier</string>
+			<key>Title</key>
+			<string>MUL_VAL_WITH_NUMBERS</string>
+			<key>Key</key>
+			<string>mulValueWithNumbers</string>
+			<key>DefaultValue</key>
+			<integer>0</integer>
+		</dict>
+		<dict>
 			<key>Type</key>
 			<string>PSGroupSpecifier</string>
 			<key>Title</key>

--- a/InAppSettingsKitTests/Settings.bundle/Root~iphone.inApp.plist
+++ b/InAppSettingsKitTests/Settings.bundle/Root~iphone.inApp.plist
@@ -69,6 +69,30 @@
 			<true/>
 		</dict>
 		<dict>
+			<key>Values</key>
+			<array>
+				<integer>0</integer>
+				<integer>1</integer>
+				<integer>2</integer>
+				<integer>3</integer>
+			</array>
+			<key>Titles</key>
+			<array>
+				<integer>0</integer>
+				<integer>1</integer>
+				<integer>2</integer>
+				<integer>3</integer>
+			</array>
+			<key>Type</key>
+			<string>PSMultiValueSpecifier</string>
+			<key>Title</key>
+			<string>MUL_VAL_WITH_NUMBERS</string>
+			<key>Key</key>
+			<string>mulValueWithNumbers</string>
+			<key>DefaultValue</key>
+			<integer>0</integer>
+		</dict>
+		<dict>
 			<key>Title</key>
 			<string>MUL_VAL_NO_TITLE</string>
 			<key>Type</key>

--- a/InAppSettingsKitTests/Settings.bundle/Root~iphone.plist
+++ b/InAppSettingsKitTests/Settings.bundle/Root~iphone.plist
@@ -97,6 +97,30 @@
 			<true/>
 		</dict>
 		<dict>
+			<key>Values</key>
+			<array>
+				<integer>0</integer>
+				<integer>1</integer>
+				<integer>2</integer>
+				<integer>3</integer>
+			</array>
+			<key>Titles</key>
+			<array>
+				<integer>0</integer>
+				<integer>1</integer>
+				<integer>2</integer>
+				<integer>3</integer>
+			</array>
+			<key>Type</key>
+			<string>PSMultiValueSpecifier</string>
+			<key>Title</key>
+			<string>MUL_VAL_WITH_NUMBERS</string>
+			<key>Key</key>
+			<string>mulValueWithNumbers</string>
+			<key>DefaultValue</key>
+			<integer>0</integer>
+		</dict>
+		<dict>
 			<key>Type</key>
 			<string>PSGroupSpecifier</string>
 			<key>Title</key>


### PR DESCRIPTION
If one want to use integers (numbers) as titles, a dedicated localisation is required.
This PR uses NSNumberFormatter to translate the title to the appropriate number (localised for the chosen locale). If the title is not an integer type, it is handled as a string (as it was before). 