### PR TITLE
Fix missing imports in Umbrella Header

### DIFF
--- a/InAppSettingsKitFramework/InAppSettingsKit.h
+++ b/InAppSettingsKitFramework/InAppSettingsKit.h
@@ -27,4 +27,6 @@ FOUNDATION_EXPORT const unsigned char InAppSettingsKitFrameworkVersionString[];
 #import <InAppSettingsKit/IASKSpecifierValuesViewController.h>
 #import <InAppSettingsKit/IASKSwitch.h>
 #import <InAppSettingsKit/IASKTextField.h>
+#import <InAppSettingsKit/IASKTextView.h>
+#import <InAppSettingsKit/IASKTextViewCell.h>
 #import <InAppSettingsKit/IASKViewController.h>

--- a/InAppSettingsKitFramework/InAppSettingsKit.h
+++ b/InAppSettingsKitFramework/InAppSettingsKit.h
@@ -15,30 +15,16 @@ FOUNDATION_EXPORT double InAppSettingsKitVersionNumber;
 FOUNDATION_EXPORT const unsigned char InAppSettingsKitFrameworkVersionString[];
 
 #import <InAppSettingsKit/IASKAppSettingsViewController.h>
-#import <InAppSettingsKit/IASKAppSettingsViewController.h>
-#import <InAppSettingsKit/IASKAppSettingsWebViewController.h>
 #import <InAppSettingsKit/IASKAppSettingsWebViewController.h>
 #import <InAppSettingsKit/IASKPSSliderSpecifierViewCell.h>
-#import <InAppSettingsKit/IASKPSSliderSpecifierViewCell.h>
-#import <InAppSettingsKit/IASKPSTextFieldSpecifierViewCell.h>
 #import <InAppSettingsKit/IASKPSTextFieldSpecifierViewCell.h>
 #import <InAppSettingsKit/IASKSettingsReader.h>
-#import <InAppSettingsKit/IASKSettingsReader.h>
-#import <InAppSettingsKit/IASKSettingsStore.h>
 #import <InAppSettingsKit/IASKSettingsStore.h>
 #import <InAppSettingsKit/IASKSettingsStoreFile.h>
-#import <InAppSettingsKit/IASKSettingsStoreFile.h>
-#import <InAppSettingsKit/IASKSettingsStoreUserDefaults.h>
 #import <InAppSettingsKit/IASKSettingsStoreUserDefaults.h>
 #import <InAppSettingsKit/IASKSlider.h>
-#import <InAppSettingsKit/IASKSlider.h>
-#import <InAppSettingsKit/IASKSpecifier.h>
 #import <InAppSettingsKit/IASKSpecifier.h>
 #import <InAppSettingsKit/IASKSpecifierValuesViewController.h>
-#import <InAppSettingsKit/IASKSpecifierValuesViewController.h>
-#import <InAppSettingsKit/IASKSwitch.h>
 #import <InAppSettingsKit/IASKSwitch.h>
 #import <InAppSettingsKit/IASKTextField.h>
-#import <InAppSettingsKit/IASKTextField.h>
-#import <InAppSettingsKit/IASKViewController.h>
 #import <InAppSettingsKit/IASKViewController.h>


### PR DESCRIPTION
When using the project Xcode gives a warning:

```
<module-includes>:1:1: warning: umbrella header for module 'InAppSettingsKit' does not include header 'IASKTextView.h'
#import "Headers/InAppSettingsKit.h"
<module-includes>:1:1: warning: umbrella header for module 'InAppSettingsKit' does not include header 'IASKTextViewCell.h'
#import "Headers/InAppSettingsKit.h"
```

This PR fixes this.