### PR TITLE
Fixes missing table view in values view.

### DIFF
--- a/InAppSettingsKit/Controllers/IASKSpecifierValuesViewController.m
+++ b/InAppSettingsKit/Controllers/IASKSpecifierValuesViewController.m
@@ -62,6 +62,7 @@
     
     if (_tableView) {
         [_tableView reloadData];
+		_selection.tableView = _tableView;
     }
 	self.didFirstLayout = NO;
 	[super viewWillAppear:animated];


### PR DESCRIPTION
If some deeper settings are opened the second time, the table view cell selection behaves a bit weird. This is because of the missing table view reference, which gets removed in viewWillDisappear. But the reference is never added again.
This is fixed. 