### PR TITLE
Fixed checked item in a PSRadioGroup isn't displayed

### DIFF
--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -107,11 +107,10 @@ CGRect IASKCGRectSwap(CGRect rect);
 	for (int i = 0; i < _settingsReader.numberOfSections; i++) {
 		IASKSpecifier *specifier = [self.settingsReader headerSpecifierForSection:i];
 		if ([specifier.type isEqualToString:kIASKPSRadioGroupSpecifier]) {
-			IASKMultipleValueSelection *selection = [IASKMultipleValueSelection new];
+			IASKMultipleValueSelection *selection = [[IASKMultipleValueSelection alloc] initWithSettingsStore:self.settingsStore];
 			selection.tableView = self.tableView;
 			selection.specifier = specifier;
 			selection.section = i;
-			selection.settingsStore = self.settingsStore;
 			[sectionSelection addObject:selection];
 		} else {
 			[sectionSelection addObject:[NSNull null]];

--- a/InAppSettingsKit/Controllers/IASKMultipleValueSelection.h
+++ b/InAppSettingsKit/Controllers/IASKMultipleValueSelection.h
@@ -13,7 +13,7 @@
 @property (nonatomic, copy, readonly) NSIndexPath *checkedItem;
 @property (nonatomic, strong) id<IASKSettingsStore> settingsStore;
 
-- (instancetype)initWithSettingsStore:(id<IASKSettingsStore>)settingsStore;
+- (id)initWithSettingsStore:(id<IASKSettingsStore>)settingsStore;
 - (void)selectRowAtIndexPath:(NSIndexPath *)indexPath;
 - (void)updateSelectionInCell:(UITableViewCell *)cell indexPath:(NSIndexPath *)indexPath;
 

--- a/InAppSettingsKit/Controllers/IASKMultipleValueSelection.h
+++ b/InAppSettingsKit/Controllers/IASKMultipleValueSelection.h
@@ -13,6 +13,7 @@
 @property (nonatomic, copy, readonly) NSIndexPath *checkedItem;
 @property (nonatomic, strong) id<IASKSettingsStore> settingsStore;
 
+- (instancetype)initWithSettingsStore:(id<IASKSettingsStore>)settingsStore;
 - (void)selectRowAtIndexPath:(NSIndexPath *)indexPath;
 - (void)updateSelectionInCell:(UITableViewCell *)cell indexPath:(NSIndexPath *)indexPath;
 

--- a/InAppSettingsKit/Controllers/IASKMultipleValueSelection.m
+++ b/InAppSettingsKit/Controllers/IASKMultipleValueSelection.m
@@ -11,10 +11,8 @@
 
 @synthesize settingsStore = _settingsStore;
 
-- (instancetype)initWithSettingsStore:(id<IASKSettingsStore>)settingsStore
-{
-    self = [super init];
-    if (self) {
+(id)initWithSettingsStore:(id<IASKSettingsStore>)settingsStore {
+    if ((self = [super init])) {
         self.settingsStore = settingsStore;
     }
     return self;

--- a/InAppSettingsKit/Controllers/IASKMultipleValueSelection.m
+++ b/InAppSettingsKit/Controllers/IASKMultipleValueSelection.m
@@ -11,7 +11,7 @@
 
 @synthesize settingsStore = _settingsStore;
 
-(id)initWithSettingsStore:(id<IASKSettingsStore>)settingsStore {
+- (id)initWithSettingsStore:(id<IASKSettingsStore>)settingsStore {
     if ((self = [super init])) {
         self.settingsStore = settingsStore;
     }

--- a/InAppSettingsKit/Controllers/IASKMultipleValueSelection.m
+++ b/InAppSettingsKit/Controllers/IASKMultipleValueSelection.m
@@ -11,6 +11,15 @@
 
 @synthesize settingsStore = _settingsStore;
 
+- (instancetype)initWithSettingsStore:(id<IASKSettingsStore>)settingsStore
+{
+    self = [super init];
+    if (self) {
+        self.settingsStore = settingsStore;
+    }
+    return self;
+}
+
 - (void)dealloc {
     [[NSNotificationCenter defaultCenter] removeObserver:self name:NSUserDefaultsDidChangeNotification object:nil];
 }


### PR DESCRIPTION
when using a custom IASKSettingsStore.

The checked item in a multiple value selection is determined immediately after IASKMultipleValueSelection is instantiated. At that time the IASKSettingsStore hasn't been set yet by the instantiating class (IASKAppSettingsViewController), therefore the default settings store was always used instead a possible custom store set by the delegate. In that case the checked item wasn't displayed in radio groups. Fixed by adding an initializer to IASKMultipleValueSelection in which you can pass the IASKSettingsStore.