### PR TITLE
Fix framework compilation for the release configuration

### DIFF
--- a/InAppSettingsKit/Views/IASKTextView.m
+++ b/InAppSettingsKit/Views/IASKTextView.m
@@ -56,7 +56,7 @@
 	[super drawRect:rect];
 	
 	if (_shouldDrawPlaceholder) {
-		[_placeholder drawAtPoint:CGPointMake(5.0, 8.0) withAttributes:@{NSFontAttributeName: self.font, NSForegroundColorAttributeName: [UIColor colorWithRed:0 green:0 blue:0.0981 alpha:0.22]}];
+		[_placeholder drawAtPoint:CGPointMake(5.0, 8.0) withAttributes:@{NSFontAttributeName: self.font, NSForegroundColorAttributeName: [UIColor colorWithRed:0.f green:0.f blue:0.0981f alpha:0.22f]}];
 	}
 }
 


### PR DESCRIPTION
Since version 2.9.0, InAppSettingsKit compilation fails when building Carthage dependencies. The relevant build log error is:

```
IASKTextView.m:59:169: error: implicit conversion loses floating-point precision: 'double' to 'CGFloat' (aka 'float') [-Werror,-Wconversion]
```

The error is due to release build settings raising an error for implicit lossy conversions between floating point values (`CGFloat` translates to `float`on 32-bit architectures, and to `double` on 64-bit ones, which can lead to issues).

I fixed the offending line by adorning color component with an `f`, marking them as `float` constants. Implicit conversion to `double` on 64-bit architecture works, and no error is raised when compiling 32-bit flavors.

Explicitly adorning floating-point constants with an `f` could be made throughout the codebase, though. I tried to keep the PR as simple as possible and thus fixed only the offending line. Whether or not you want to consider extending such practices to the rest of your codebase is ultimately your decision.

Thanks for your work on this framework.

Best regards.

