### PR TITLE
Bug fix - Title/footer of Group not matching idiom were displayed.

### DIFF
--- a/InAppSettingsKit/Models/IASKSettingsReader.m
+++ b/InAppSettingsKit/Models/IASKSettingsReader.m
@@ -145,6 +145,13 @@
         if ([self.hiddenKeys containsObject:newSpecifier.key]) {
             continue;
         }
+
+        if (![newSpecifier.userInterfaceIdioms containsObject:@(UI_USER_INTERFACE_IDIOM())]) {
+            // All specifiers without a matching idiom are ignored in the iOS Settings app, so we will do likewise here.
+            // Some specifiers may be seen as containing other elements, such as groups, but the iOS settings app will not ignore the perceived content of those unless their own supported idioms do not fit.
+            continue;
+        }
+
         NSString *type = newSpecifier.type;
         if ([type isEqualToString:kIASKPSGroupSpecifier]
             || [type isEqualToString:kIASKPSRadioGroupSpecifier]) {
@@ -168,9 +175,7 @@
                 [dataSource addObject:[NSMutableArray array]];
             }
             
-            if ([newSpecifier.userInterfaceIdioms containsObject:@(UI_USER_INTERFACE_IDIOM())]) {
-                [(NSMutableArray*)dataSource.lastObject addObject:newSpecifier];
-            }
+            [(NSMutableArray*)dataSource.lastObject addObject:newSpecifier];
         }
     }
     [self setDataSource:dataSource];


### PR DESCRIPTION
All specifiers without a matching idiom are ignored in the iOS Settings app, including groups.  This change moves the idiom check to be not specifier-type conditional.

Problem was found when setting SupportedUserInterfaceIdioms on all elements within a Group and on the Group itself.  Title and footer were still displayed in InAppSettingsKit but not in the Settings app.

Further testing was performed to ensure that the RadioGroup was properly grouped or ungrouped (based on observations in the code) and that consecutive groups were also handled in a style matching the Settings app.  The former does not imply a group break following the radio group (following elements will appear flush below the radio group, and the footer for the radio group will follow them) and the latter renders each consecutive group as additional space.  In both cases all was well and no changes related to those were made.