### PR TITLE
Fix unintended animations when returning to settings view controller.

### DIFF
--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -186,10 +186,12 @@ CGRect IASKCGRectSwap(CGRect rect);
 	// so reload that row
 	if(selectedIndexPath) {
 		dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(animated * UINavigationControllerHideShowBarDuration * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+			[CATransaction setDisableActions:YES];
 			[self.tableView reloadRowsAtIndexPaths:[NSArray arrayWithObject:selectedIndexPath]
 								  withRowAnimation:UITableViewRowAnimationNone];
 			// and reselect it, so we get the nice default deselect animation from UITableViewController
 			[self.tableView selectRowAtIndexPath:selectedIndexPath animated:NO scrollPosition:UITableViewScrollPositionNone];
+			[CATransaction setDisableActions:NO];
 			[self.tableView deselectRowAtIndexPath:selectedIndexPath animated:YES];
 		});
 	}


### PR DESCRIPTION
Currently, when I return to the settings view controller after having selected a row, it sometimes animates in unexpected ways:

![chinese](https://user-images.githubusercontent.com/227043/41465176-f892b266-706a-11e8-9b9d-d048d584faad.gif)

According to this [stack overflow post](https://stackoverflow.com/a/16053596/251038), Apple has said that UITableViewRowAnimationNone is not enough to guarantee no animation:

>The animation parameter merely defines how the row is inserted into the space (e.g. slide from the right/left/etc), the transitions to create that space are animated regardless of what user wants.

The fix is to disable animation at the Core Animation layer as well.
