### PR TITLE
Add an OK button to the iOS 8+ version of the "Mail not Configured" alert.

### DIFF
--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -877,6 +877,9 @@ CGRect IASKCGRectSwap(CGRect rect);
 			UIAlertController *alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Mail not configured", @"InAppSettingsKit")
 																		   message:NSLocalizedString(@"This device is not configured for sending Email. Please configure the Mail settings in the Settings app.", @"InAppSettingsKit")
 																	preferredStyle:UIAlertControllerStyleAlert];
+            [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"OK", @"InAppSettingsKit") style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
+                [alert dismissViewControllerAnimated:YES completion:nil];
+            }]];
 			[self presentViewController:alert animated:YES completion:nil];
 #else
 			UIAlertView *alert = [[UIAlertView alloc]


### PR DESCRIPTION
Without this, the alert is not dismissible, and the app must be force-quit.

Before:
![simulator screen shot - iphone se english - 2018-10-13 at 16 41 36](https://user-images.githubusercontent.com/227043/46909838-0e833280-cf07-11e8-80cf-31081051dd93.png)

After:
![simulator screen shot - iphone se english - 2018-10-13 at 16 43 28](https://user-images.githubusercontent.com/227043/46909840-1e9b1200-cf07-11e8-8d05-4643c7d24c39.png)
