### PR TITLE
Improved header and footer customization

### DIFF
--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.h
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.h
@@ -29,12 +29,26 @@
 
 @optional
 #pragma mark - UITableView header customization
+- (NSString *) settingsViewController:(id<IASKViewController>)settingsViewController
+                            tableView:(UITableView *)tableView
+             titleForHeaderForSection:(NSInteger)section;
 - (CGFloat) settingsViewController:(id<IASKViewController>)settingsViewController
                          tableView:(UITableView *)tableView
          heightForHeaderForSection:(NSInteger)section;
 - (UIView *) settingsViewController:(id<IASKViewController>)settingsViewController
                           tableView:(UITableView *)tableView
             viewForHeaderForSection:(NSInteger)section;
+
+#pragma mark - UITableView footer customization
+- (NSString *) settingsViewController:(id<IASKViewController>)settingsViewController
+                            tableView:(UITableView *)tableView
+             titleForFooterForSection:(NSInteger)section;
+- (CGFloat) settingsViewController:(id<IASKViewController>)settingsViewController
+                         tableView:(UITableView *)tableView
+         heightForFooterForSection:(NSInteger)section;
+- (UIView *) settingsViewController:(id<IASKViewController>)settingsViewController
+                          tableView:(UITableView *)tableView
+            viewForFooterForSection:(NSInteger)section;
 
 #pragma mark - UITableView cell customization
 - (CGFloat)tableView:(UITableView*)tableView heightForSpecifier:(IASKSpecifier*)specifier;

--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -446,11 +446,11 @@ CGRect IASKCGRectSwap(CGRect rect);
 }
 
 - (NSString *)tableView:(UITableView*)tableView titleForHeaderInSection:(NSInteger)section {
-    NSString *header = [self.settingsReader titleForSection:section];
-	if (0 == header.length) {
-		return nil;
-	}
-	return header;
+    NSString *headerText = [self.delegate respondsToSelector:@selector(settingsViewController:tableView:titleForHeaderForSection:)] ? [self.delegate settingsViewController:self tableView:tableView titleForHeaderForSection:section] : nil;
+    if (headerText.length == 0) {
+        headerText = [self.settingsReader titleForSection:section];
+    }
+    return (headerText.length != 0) ? headerText : nil;
 }
 
 - (UIView *)tableView:(UITableView*)tableView viewForHeaderInSection:(NSInteger)section {
@@ -467,17 +467,20 @@ CGRect IASKCGRectSwap(CGRect rect);
 		if (result > 0) {
 			return result;
 		}
-		
 	}
 	return UITableViewAutomaticDimension;
 }
 
 - (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
 {
-	NSString *footerText = [self.settingsReader footerTextForSection:section];
+    NSString *footerText = [self.delegate respondsToSelector:@selector(settingsViewController:tableView:titleForFooterForSection:)] ? [self.delegate settingsViewController:self tableView:tableView titleForFooterForSection:section] : nil;
+    if (footerText.length == 0) {
+        footerText = [self.settingsReader footerTextForSection:section];
+    }
+    
 	if (_showCreditsFooter && (section == [self.settingsReader numberOfSections]-1)) {
 		// show credits since this is the last section
-		if ((footerText == nil) || ([footerText length] == 0)) {
+		if (footerText.length == 0) {
 			// show the credits on their own
 			return kIASKCredits;
 		} else {
@@ -489,6 +492,23 @@ CGRect IASKCGRectSwap(CGRect rect);
 	}
 }
 
+- (UIView *)tableView:(UITableView*)tableView viewForFooterInSection:(NSInteger)section {
+    if ([self.delegate respondsToSelector:@selector(settingsViewController:tableView:viewForFooterForSection:)]) {
+        return [self.delegate settingsViewController:self tableView:tableView viewForFooterForSection:section];
+    } else {
+        return nil;
+    }
+}
+
+- (CGFloat)tableView:(UITableView*)tableView heightForFooterInSection:(NSInteger)section {
+    if ([self tableView:tableView viewForFooterInSection:section] && [self.delegate respondsToSelector:@selector(settingsViewController:tableView:heightForFooterForSection:)]) {
+        CGFloat result = [self.delegate settingsViewController:self tableView:tableView heightForFooterForSection:section];
+        if (result > 0) {
+            return result;
+        }
+    }
+    return UITableViewAutomaticDimension;
+}
 
 - (UITableViewCell*)tableView:(UITableView *)tableView newCellForSpecifier:(IASKSpecifier*)specifier {
 

--- a/InAppSettingsKitSampleApp/Classes/MainViewController.m
+++ b/InAppSettingsKitSampleApp/Classes/MainViewController.m
@@ -159,41 +159,63 @@
     }
 }
 - (CGFloat)settingsViewController:(id<IASKViewController>)settingsViewController
-                        tableView:(UITableView *)tableView 
+                        tableView:(UITableView *)tableView
         heightForHeaderForSection:(NSInteger)section {
-  NSString* key = [settingsViewController.settingsReader keyForSection:section];
-	if ([key isEqualToString:@"IASKLogo"]) {
-		return [UIImage imageNamed:@"Icon.png"].size.height + 25;
-	} else if ([key isEqualToString:@"IASKCustomHeaderStyle"]) {
-		return 55.f;    
-  }
-	return 0;
+    NSString *key = [settingsViewController.settingsReader keyForSection:section];
+    if ([key isEqualToString:@"IASKLogo"]) {
+        return [UIImage imageNamed:@"Icon.png"].size.height + 25;
+    } else if ([key isEqualToString:@"IASKCustomHeaderStyle"]) {
+        return 55.f;
+    }
+    return 0;
 }
 
 - (UIView *)settingsViewController:(id<IASKViewController>)settingsViewController
                          tableView:(UITableView *)tableView 
-               viewForHeaderForSection:(NSInteger)section {
-  NSString* key = [settingsViewController.settingsReader keyForSection:section];
-	if ([key isEqualToString:@"IASKLogo"]) {
-		UIImageView *imageView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"Icon.png"]];
-		imageView.contentMode = UIViewContentModeCenter;
-		return imageView;
-	} else if ([key isEqualToString:@"IASKCustomHeaderStyle"]) {
-    UILabel* label = [[UILabel alloc] initWithFrame:CGRectZero];
-    label.backgroundColor = [UIColor clearColor];
-    label.textAlignment = NSTextAlignmentCenter;
-    label.textColor = [UIColor redColor];
-    label.shadowColor = [UIColor whiteColor];
-    label.shadowOffset = CGSizeMake(0, 1);
-    label.numberOfLines = 0;
-    label.font = [UIFont boldSystemFontOfSize:16.f];
-    
-    //figure out the title from settingsbundle
-    label.text = [settingsViewController.settingsReader titleForSection:section];
-    
-    return label;
-  }
+           viewForHeaderForSection:(NSInteger)section {
+    NSString *key = [settingsViewController.settingsReader keyForSection:section];
+    if ([key isEqualToString:@"IASKLogo"]) {
+        UIImageView *imageView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"Icon.png"]];
+        imageView.contentMode = UIViewContentModeCenter;
+        return imageView;
+    } else if ([key isEqualToString:@"IASKCustomHeaderStyle"]) {
+        UILabel *label = [[UILabel alloc] initWithFrame:CGRectZero];
+        label.backgroundColor = [UIColor clearColor];
+        label.textAlignment = NSTextAlignmentCenter;
+        label.textColor = [UIColor redColor];
+        label.shadowColor = [UIColor whiteColor];
+        label.shadowOffset = CGSizeMake(0, 1);
+        label.numberOfLines = 0;
+        label.font = [UIFont boldSystemFontOfSize:16.f];
+        
+        //figure out the title from settingsbundle
+        label.text = [settingsViewController.settingsReader titleForSection:section];
+        
+        return label;
+    }
 	return nil;
+}
+
+- (CGFloat)settingsViewController:(id<IASKViewController>)settingsViewController
+                        tableView:(UITableView *)tableView
+        heightForFooterForSection:(NSInteger)section {
+    NSString *key = [settingsViewController.settingsReader keyForSection:section];
+    if ([key isEqualToString:@"IASKLogo"]) {
+        return [UIImage imageNamed:@"Icon.png"].size.height + 25;
+    }
+    return 0;
+}
+
+- (UIView *)settingsViewController:(id<IASKViewController>)settingsViewController
+                         tableView:(UITableView *)tableView
+           viewForFooterForSection:(NSInteger)section {
+    NSString *key = [settingsViewController.settingsReader keyForSection:section];
+    if ([key isEqualToString:@"IASKLogo"]) {
+        UIImageView *imageView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"Icon.png"]];
+        imageView.contentMode = UIViewContentModeCenter;
+        return imageView;
+    }
+    return nil;
 }
 
 - (CGFloat)tableView:(UITableView*)tableView heightForSpecifier:(IASKSpecifier*)specifier {

--- a/InAppSettingsKitSampleApp/Classes/MainViewController.m
+++ b/InAppSettingsKitSampleApp/Classes/MainViewController.m
@@ -196,6 +196,14 @@
 	return nil;
 }
 
+- (NSString *)settingsViewController:(id<IASKViewController>)settingsViewController tableView:(UITableView *)tableView titleForHeaderForSection:(NSInteger)section {
+    NSString *key = [settingsViewController.settingsReader keyForSection:section];
+    if ([key isEqualToString:@"CUSTOM_HEADER_FOOTER"]) {
+        return @"Custom header title";
+    }
+    return nil;
+}
+
 - (CGFloat)settingsViewController:(id<IASKViewController>)settingsViewController
                         tableView:(UITableView *)tableView
         heightForFooterForSection:(NSInteger)section {
@@ -214,6 +222,14 @@
         UIImageView *imageView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"Icon.png"]];
         imageView.contentMode = UIViewContentModeCenter;
         return imageView;
+    }
+    return nil;
+}
+
+- (NSString *)settingsViewController:(id<IASKViewController>)settingsViewController tableView:(UITableView *)tableView titleForFooterForSection:(NSInteger)section {
+    NSString *key = [settingsViewController.settingsReader keyForSection:section];
+    if ([key isEqualToString:@"CUSTOM_HEADER_FOOTER"]) {
+        return @"Custom footer title";
     }
     return nil;
 }

--- a/InAppSettingsKitSampleApp/Settings.bundle/Root.inApp.plist
+++ b/InAppSettingsKitSampleApp/Settings.bundle/Root.inApp.plist
@@ -475,6 +475,24 @@ with dynamically resizing cell</string>
 			<string>AutoConnectPassword</string>
 		</dict>
 		<dict>
+			<key>Key</key>
+			<string>CUSTOM_HEADER_FOOTER</string>
+			<key>Title</key>
+			<string></string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>Key</key>
+			<string>ButtonDemoAction4</string>
+			<key>Title</key>
+			<string>Button</string>
+			<key>Type</key>
+			<string>IASKButtonSpecifier</string>
+			<key>IASKTextAlignment</key>
+			<string>IASKUITextAlignmentLeft</string>
+		</dict>
+		<dict>
 			<key>Title</key>
 			<string>APPLICATION_INFO_TITLE</string>
 			<key>Type</key>

--- a/InAppSettingsKitSampleApp/Settings.bundle/Root~ipad.inApp.plist
+++ b/InAppSettingsKitSampleApp/Settings.bundle/Root~ipad.inApp.plist
@@ -487,6 +487,24 @@ with dynamically resizing cell</string>
 			<string>AutoConnectPassword</string>
 		</dict>
 		<dict>
+			<key>Key</key>
+			<string>CUSTOM_HEADER_FOOTER</string>
+			<key>Title</key>
+			<string></string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>Key</key>
+			<string>ButtonDemoAction4</string>
+			<key>Title</key>
+			<string>Button</string>
+			<key>Type</key>
+			<string>IASKButtonSpecifier</string>
+			<key>IASKTextAlignment</key>
+			<string>IASKUITextAlignmentLeft</string>
+		</dict>
+		<dict>
 			<key>Title</key>
 			<string>APPLICATION_INFO_TITLE</string>
 			<key>Type</key>

--- a/InAppSettingsKitSampleApp/Settings.bundle/Root~ipad.plist
+++ b/InAppSettingsKitSampleApp/Settings.bundle/Root~ipad.plist
@@ -8,27 +8,27 @@
 	<string>Root</string>
 	<key>PreferenceSpecifiers</key>
 	<array>
-        <dict>
+		<dict>
 			<key>Key</key>
 			<string>FacebookButton</string>
 			<key>Title</key>
 			<string>Facebook</string>
-            <key>IASKCellImage</key>
-            <string>facebook</string>
-            <key>IASKTextAlignment</key>
-            <string>IASKUITextAlignmentCenter</string>
+			<key>IASKCellImage</key>
+			<string>facebook</string>
+			<key>IASKTextAlignment</key>
+			<string>IASKUITextAlignmentCenter</string>
 			<key>Type</key>
 			<string>IASKButtonSpecifier</string>
 		</dict>
-        <dict>
+		<dict>
 			<key>Key</key>
 			<string>TwitterButton</string>
 			<key>Title</key>
 			<string>Twitter</string>
-            <key>IASKCellImage</key>
-            <string>twitter</string>
-            <key>IASKTextAlignment</key>
-            <string>IASKUITextAlignmentLeft</string>
+			<key>IASKCellImage</key>
+			<string>twitter</string>
+			<key>IASKTextAlignment</key>
+			<string>IASKUITextAlignmentLeft</string>
 			<key>Type</key>
 			<string>IASKButtonSpecifier</string>
 		</dict>
@@ -161,6 +161,24 @@
 			<string>ADVANCED_TITLE</string>
 			<key>File</key>
 			<string>Advanced</string>
+		</dict>
+		<dict>
+			<key>Key</key>
+			<string>CUSTOM_HEADER_FOOTER</string>
+			<key>Title</key>
+			<string></string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>Key</key>
+			<string>ButtonDemoAction4</string>
+			<key>Title</key>
+			<string>Button</string>
+			<key>Type</key>
+			<string>IASKButtonSpecifier</string>
+			<key>IASKTextAlignment</key>
+			<string>IASKUITextAlignmentLeft</string>
 		</dict>
 		<dict>
 			<key>Title</key>

--- a/InAppSettingsKitSampleApp/Settings.bundle/Root~iphone.inApp.plist
+++ b/InAppSettingsKitSampleApp/Settings.bundle/Root~iphone.inApp.plist
@@ -487,6 +487,24 @@ with dynamically resizing cell</string>
 			<string>AutoConnectPassword</string>
 		</dict>
 		<dict>
+			<key>Key</key>
+			<string>CUSTOM_HEADER_FOOTER</string>
+			<key>Title</key>
+			<string></string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>Key</key>
+			<string>ButtonDemoAction4</string>
+			<key>Title</key>
+			<string>Button</string>
+			<key>Type</key>
+			<string>IASKButtonSpecifier</string>
+			<key>IASKTextAlignment</key>
+			<string>IASKUITextAlignmentLeft</string>
+		</dict>
+		<dict>
 			<key>Title</key>
 			<string>APPLICATION_INFO_TITLE</string>
 			<key>Type</key>

--- a/InAppSettingsKitTests/Settings.bundle/Root.inApp.plist
+++ b/InAppSettingsKitTests/Settings.bundle/Root.inApp.plist
@@ -441,6 +441,24 @@
 			<string>AutoConnectPassword</string>
 		</dict>
 		<dict>
+			<key>Key</key>
+			<string>CUSTOM_HEADER_FOOTER</string>
+			<key>Title</key>
+			<string></string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>Key</key>
+			<string>ButtonDemoAction4</string>
+			<key>Title</key>
+			<string>Button</string>
+			<key>Type</key>
+			<string>IASKButtonSpecifier</string>
+			<key>IASKTextAlignment</key>
+			<string>IASKUITextAlignmentLeft</string>
+		</dict>
+		<dict>
 			<key>Title</key>
 			<string>APPLICATION_INFO_TITLE</string>
 			<key>Type</key>

--- a/InAppSettingsKitTests/Settings.bundle/Root~ipad.inApp.plist
+++ b/InAppSettingsKitTests/Settings.bundle/Root~ipad.inApp.plist
@@ -463,6 +463,24 @@
 			<string>AutoConnectPassword</string>
 		</dict>
 		<dict>
+			<key>Key</key>
+			<string>CUSTOM_HEADER_FOOTER</string>
+			<key>Title</key>
+			<string></string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>Key</key>
+			<string>ButtonDemoAction4</string>
+			<key>Title</key>
+			<string>Button</string>
+			<key>Type</key>
+			<string>IASKButtonSpecifier</string>
+			<key>IASKTextAlignment</key>
+			<string>IASKUITextAlignmentLeft</string>
+		</dict>
+		<dict>
 			<key>Title</key>
 			<string>APPLICATION_INFO_TITLE</string>
 			<key>Type</key>

--- a/InAppSettingsKitTests/Settings.bundle/Root~iphone.inApp.plist
+++ b/InAppSettingsKitTests/Settings.bundle/Root~iphone.inApp.plist
@@ -463,6 +463,24 @@
 			<string>AutoConnectPassword</string>
 		</dict>
 		<dict>
+			<key>Key</key>
+			<string>CUSTOM_HEADER_FOOTER</string>
+			<key>Title</key>
+			<string></string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>Key</key>
+			<string>ButtonDemoAction4</string>
+			<key>Title</key>
+			<string>Button</string>
+			<key>Type</key>
+			<string>IASKButtonSpecifier</string>
+			<key>IASKTextAlignment</key>
+			<string>IASKUITextAlignmentLeft</string>
+		</dict>
+		<dict>
 			<key>Title</key>
 			<string>APPLICATION_INFO_TITLE</string>
 			<key>Type</key>

--- a/README.md
+++ b/README.md
@@ -198,8 +198,8 @@ to catch tap events for your custom view.
 
 
 
-Custom Group Header Views
--------------------------
+Custom Group Header and Footer Views
+------------------------------------
 You can define custom headers for `PSGroupSpecifier` segments by adding a `Key` attribute and implementing these methods in your `IASKSettingsDelegate`:
 
     - (CGFloat)settingsViewController:(id<IASKViewController>)settingsViewController tableView:(UITableView*)tableView heightForHeaderForSection:(NSInteger)section;
@@ -207,6 +207,7 @@ You can define custom headers for `PSGroupSpecifier` segments by adding a `Key` 
 
 The behaviour is similar to the custom cells except that the methods get the key directly as a string, not via a `IASKSpecifier` object. (The reason being that custom group header views are meant to be static.) Again, check the example in the demo app.
 
+Corresponding methods are provided for footer views as well.
 
 Custom ViewControllers
 ----------------------

--- a/README.md
+++ b/README.md
@@ -198,16 +198,29 @@ to catch tap events for your custom view.
 
 
 
-Custom Group Header and Footer Views
-------------------------------------
-You can define custom headers for `PSGroupSpecifier` segments by adding a `Key` attribute and implementing these methods in your `IASKSettingsDelegate`:
+Custom Group Headers and Footers
+--------------------------------
+You can define a custom header view for `PSGroupSpecifier` segments by adding a `Key` attribute and implementing the following method in your `IASKSettingsDelegate`:
+    
+	- (UIView *)settingsViewController:(id<IASKViewController>)settingsViewController tableView:(UITableView *)tableView viewForHeaderForSection:(NSInteger)section;
 
-    - (CGFloat)settingsViewController:(id<IASKViewController>)settingsViewController tableView:(UITableView*)tableView heightForHeaderForSection:(NSInteger)section;
-    - (UIView*)settingsViewController:(id<IASKViewController>)settingsViewController tableView:(UITableView *)tableView viewForHeaderForSection:(NSString*)key;
+You can adjust the height of the header by implementing the following method:
 
-The behaviour is similar to the custom cells except that the methods get the key directly as a string, not via a `IASKSpecifier` object. (The reason being that custom group header views are meant to be static.) Again, check the example in the demo app.
+	- (CGFloat)settingsViewController:(id<IASKViewController>)settingsViewController tableView:(UITableView*)tableView heightForHeaderForSection:(NSInteger)section;
 
-Corresponding methods are provided for footer views as well.
+For simpler header title customization without the need for a custom view, and provided the `-settingsViewController:tableView:viewForHeaderForSection:` method has not been implemented or returns `nil` for the section, implement the following method:
+
+	- (NSString *)settingsViewController:(id<IASKViewController>)settingsViewController tableView:(UITableView*)tableView titleForHeaderForSection:(NSInteger)section;
+
+If the method returns `nil` or a 0-length string, the title defined in the `.plist` will be used.
+
+This behaviour is similar to custom table view cells. When implementin a method and if you need it, the section key can be retrieved from its index conveniently with:
+
+	NSString *key = [settingsViewController.settingsReader keyForSection:section];
+
+Check the demo app for a concrete example.
+
+For footer customization, three methods from the `IASKSettingsDelegate` protocol can be similarly implemented.
 
 Custom ViewControllers
 ----------------------


### PR DESCRIPTION
As of version 2.9.1, InAppSettingsKit features a way to [customize table view headers](https://github.com/futuretap/InAppSettingsKit/tree/2.9.1#custom-group-header-views) through delegate methods. No such customization is currently possible for footers, though, a limitation already discussed in a now closed issue (#213). A suggested workaround was to use headers instead, but this is not as convenient as it could be since `UITableView` provides native footer support.

Moreover, simply customizing a header title at runtime is cumbersome since it requires creating a dedicated view. Since `UITableView` also provides easy title customization, I though this feature would be very handy at the InAppSettingsKit level. For consistency, I extended this mechanism to footers as well.

More details are provided below. Thanks in advance for considering this pull request!

### Footer customization

This pull request adds a way to customize footers in the same way headers can be tweaked. By extending the existing `IASKSettingsDelegate` protocol  with the new methods `-settingsViewController:tableView:viewForFooterForSection:` and `-settingsViewController:tableView:heightForFooterForSection:`, custom footer views with custom heights can now be set, exactly in the same way as headers.

### Simple header and footer title customization

Customizing headers and footers with views was cumbersome when a simple title needed to be set. I therefore added a way to set header and footer titles at runtime, in the form of two `-settingsViewController:tableView:titleForHeaderForSection:` and `-settingsViewController:tableView:titleForFooterForSection:` delegate methods.

### Order of importance

As for usual table views, if a custom view has been defined, it is used first. If no custom view has been set (the custom view delegate method returns `nil` or has not been implemented), the title is retrieved from the new title customization delegate method, provided it has been implemented and returns a string with length > 0.

If no customization is made via delegate methods, the `.plist` title is used, as before.

### Compatibility

No breaking change has been made, this approach only adds new possibilities on top of the existing ones. Existing code will continue to work as is.

### Examples

I updated the sample applications to display a new footer view, as well as a new section with custom header and footer titles.

### Documentation

The documentation was updated to explain how customization works for headers and titles.

### Consistency

The zero-length criterium for titles could be up for debate, but was [already used in the existing codebase](https://github.com/futuretap/InAppSettingsKit/blob/2.9.1/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m#L448-L453). I therefore followed the same convention for footer code, as well as for custom title support.