### PR TITLE
Table animation glitches

### DIFF
--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -227,8 +227,10 @@ CGRect IASKCGRectSwap(CGRect rect);
 	[dc addObserver:self selector:@selector(reload) name:UIApplicationWillEnterForegroundNotification object:[UIApplication sharedApplication]];
 	[dc addObserver:self selector:@selector(synchronizeSettings) name:UIApplicationWillTerminateNotification object:[UIApplication sharedApplication]];
 
-	[self.tableView beginUpdates];
-	[self.tableView endUpdates];
+    [UIView performWithoutAnimation:^{
+        [self.tableView beginUpdates];
+        [self.tableView endUpdates];
+    }];
 }
 
 - (void)viewWillDisappear:(BOOL)animated {

--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -226,11 +226,6 @@ CGRect IASKCGRectSwap(CGRect rect);
 	[dc addObserver:self selector:@selector(synchronizeSettings) name:UIApplicationDidEnterBackgroundNotification object:[UIApplication sharedApplication]];
 	[dc addObserver:self selector:@selector(reload) name:UIApplicationWillEnterForegroundNotification object:[UIApplication sharedApplication]];
 	[dc addObserver:self selector:@selector(synchronizeSettings) name:UIApplicationWillTerminateNotification object:[UIApplication sharedApplication]];
-
-    [UIView performWithoutAnimation:^{
-        [self.tableView beginUpdates];
-        [self.tableView endUpdates];
-    }];
 }
 
 - (void)viewWillDisappear:(BOOL)animated {

--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -627,7 +627,7 @@ CGRect IASKCGRectSwap(CGRect rect);
 		textCell.textView.placeholder = specifier.placeholder;
 		
 		dispatch_async(dispatch_get_main_queue(), ^{
-			[self cacheRowHeightForTextView:textCell.textView];
+            [self cacheRowHeightForTextView:textCell.textView animated:NO];
 		});
 	}
 	else if ([specifier.type isEqualToString:kIASKPSSliderSpecifier]) {
@@ -954,7 +954,7 @@ CGRect IASKCGRectSwap(CGRect rect);
 }
 
 - (void)textViewDidChange:(IASKTextView *)textView {
-	[self cacheRowHeightForTextView:textView];
+    [self cacheRowHeightForTextView:textView animated:YES];
 	
 	CGRect visibleTableRect = UIEdgeInsetsInsetRect(self.tableView.bounds, self.tableView.contentInset);
 	NSIndexPath *indexPath = [self.settingsReader indexPathForKey:textView.key];
@@ -971,14 +971,23 @@ CGRect IASKCGRectSwap(CGRect rect);
 	
 }
 
-- (void)cacheRowHeightForTextView:(IASKTextView *)textView {
+- (void)cacheRowHeightForTextView:(IASKTextView *)textView animated:(BOOL)animated {
 	CGFloat maxHeight = self.tableView.bounds.size.height - self.tableView.contentInset.top - self.tableView.contentInset.bottom - 60;
 	CGFloat contentHeight = [textView sizeThatFits:CGSizeMake(textView.frame.size.width, 10000)].height + 16;
 	self.rowHeights[textView.key] = @(MAX(44, MIN(maxHeight, contentHeight)));
 	textView.scrollEnabled = contentHeight > maxHeight;
 
-	[self.tableView beginUpdates];
-	[self.tableView endUpdates];
+    void (^actions)(void) = ^{
+        [self.tableView beginUpdates];
+        [self.tableView endUpdates];
+    };
+    
+    if (animated) {
+        actions();
+    }
+    else {
+        [UIView performWithoutAnimation:actions];
+    }
 }
 
 #pragma mark Notifications


### PR DESCRIPTION
When navigating between settings view controllers, animation glitches are sometimes visible when the view appears:

- Footer size might slightly change, leading to a small visible bumps.
- When navigating back, the table view content offset changes abruptly.
- Content displayed in child panes created from companion plists moves up when appearing.

I made a [short video](https://drive.google.com/open?id=1FXK8ZVzlXGxiUty8XFwBhd1GgNU_Tq1t) showing these issues within the app I am working on:

- When displaying the first navigation level, the footer moves down.
- When showing license information (generated with [license-plist](https://github.com/mono0926/LicensePlist)), the content moves up.
- When navigating back a few times from the _Server settings_ subsection, the scroll view content offset moves erratically.

 I could not reproduce these issues with the sample app, but I can of course try to provide a separate sample project if required.

### Analysis

I could relate these issues with the [animated reload](https://github.com/futuretap/InAppSettingsKit/blob/2.9.1/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m#L230-L231) performed in `-viewDidAppear:` by calling `-beginUpdates` and `-endUpdates` immediately afterwards, on the table view. According to the commit log, these calls have been added to support dynamic cell height in InAppSettingsKit (see 79adb346655bd787947ac4151b74b2c6d312d262).

IMHO, this trick to force a reload is dangerous and can potentially lead to unnecessary animations. 

### Solution proposal

I propose to remove the two offending lines entirely. Upon first use, the table view is loaded anyway, and further reloads when the view is revealed by navigating back are not necessary.

Note that another `-beginUpdates` and `-endUpdates` pair is used when [calculating a text view height](https://github.com/futuretap/InAppSettingsKit/blob/2.9.1/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m#L978-L979). The related method is called [when building cells](https://github.com/futuretap/InAppSettingsKit/blob/2.9.1/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m#L627-L629), as well as [when a text view content changes](https://github.com/futuretap/InAppSettingsKit/blob/2.9.1/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m#L955). 

The animation taking place when the text changes is legitimate (the result obtained by disabling it is not bad either). The same animated approach should definitely be avoided when building cells, though (you can see that the table expands when reaching the text view section in the _Complete list_ demo). I therefore propose that a new `animated` parameter is added to `cacheRowHeightForTextView:`, so that the height calculation can be made with no animation while building the table, and with animation when resizing the text view.

I still think that this way of using `-beginUpdates` and `-endUpdates` should best be avoided, but I strived to keep changes minimal.

### Tests

I tested the new implementation with the sample app, on a variety of iPhone and iPad devices running iOS 9 to 12. The behavior seems correct to me, all text views behave as before (focus management remains a problem, as for the original code, but this is usually a tricky thing). All table view layouts seem correct. Text size changes in the system accessibility settings work correctly as well.

Moreover, the animation seen when scrolling down in the _Complete list_ demo disappears.

Finally, when using the updated version within our app, all glitches magically disappear.

### Impact

After testing this fix, I am confident that everything should work as expected, but your experience might tell otherwise. In any case, I am ready to discuss any potential issue you might know about, or to share some sample code if required. Just let me know.

Thanks in advance for considering this pull request!





