### PR TITLE
support specifiying icons in multivalue selection

### DIFF
--- a/InAppSettingsKit/Controllers/IASKSpecifierValuesViewController.m
+++ b/InAppSettingsKit/Controllers/IASKSpecifierValuesViewController.m
@@ -93,6 +93,7 @@
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     UITableViewCell *cell   = [tableView dequeueReusableCellWithIdentifier:kCellValue];
     NSArray *titles         = [_currentSpecifier multipleTitles];
+    NSArray *iconNames      = [_currentSpecifier multipleIconNames];
 	
     if (!cell) {
         cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:kCellValue];
@@ -101,9 +102,17 @@
     [_selection updateSelectionInCell:cell indexPath:indexPath];
 
     @try {
-		[[cell textLabel] setText:[self.settingsReader titleForId:[titles objectAtIndex:indexPath.row]]];
-	}
-	@catch (NSException * e) {}
+        [[cell textLabel] setText:[self.settingsReader titleForId:[titles objectAtIndex:indexPath.row]]];
+        if ((NSInteger)iconNames.count > indexPath.row) {
+            NSString *iconName = iconNames[indexPath.row];
+            // This tries to read the image from the main bundle. As this is currently not supported in
+            // system settings, this should be the correct behaviour. (Idea: abstract away and try different
+            // paths?)
+            UIImage *image = [UIImage imageNamed:iconName];
+            cell.imageView.image = image;
+        }
+    }
+    @catch (NSException * e) {}
     return cell;
 }
 

--- a/InAppSettingsKit/Models/IASKSettingsReader.h
+++ b/InAppSettingsKit/Models/IASKSettingsReader.h
@@ -37,6 +37,7 @@
 #define kIASKAutoCorrectionType               @"AutocorrectionType"
 #define kIASKValues                           @"Values"
 #define kIASKTitles                           @"Titles"
+#define kIASKIconNames                        @"IconNames"
 #define kIASKShortTitles                      @"ShortTitles"
 #define kIASKSupportedUserInterfaceIdioms     @"SupportedUserInterfaceIdioms"
 #define kIASKSubtitle                         @"IASKSubtitle"

--- a/InAppSettingsKit/Models/IASKSpecifier.h
+++ b/InAppSettingsKit/Models/IASKSpecifier.h
@@ -43,6 +43,7 @@
 - (NSInteger)multipleValuesCount;
 - (NSArray*)multipleValues;
 - (NSArray*)multipleTitles;
+- (NSArray *)multipleIconNames;
 - (NSString*)file;
 - (id)defaultValue;
 - (id)defaultStringValue;

--- a/InAppSettingsKit/Models/IASKSpecifier.m
+++ b/InAppSettingsKit/Models/IASKSpecifier.m
@@ -55,6 +55,7 @@
     }
     return self;
 }
+
 - (void)updateMultiValuesDict {
     NSArray *values = [_specifierDict objectForKey:kIASKValues];
     NSArray *titles = [_specifierDict objectForKey:kIASKTitles];
@@ -63,31 +64,38 @@
 
 - (void)setMultipleValuesDictValues:(NSArray*)values titles:(NSArray*)titles {
     NSArray *shortTitles = [_specifierDict objectForKey:kIASKShortTitles];
+    NSArray *iconNames = [_specifierDict objectForKey:kIASKIconNames];
     NSMutableDictionary *multipleValuesDict = [NSMutableDictionary new];
    
     if (values) {
-		[multipleValuesDict setObject:values forKey:kIASKValues];
-	}
+        [multipleValuesDict setObject:values forKey:kIASKValues];
+    }
 	
     if (titles) {
-		[multipleValuesDict setObject:titles forKey:kIASKTitles];
-	}
-    
+        [multipleValuesDict setObject:titles forKey:kIASKTitles];
+    }
+
     if (shortTitles.count) {
-		[multipleValuesDict setObject:shortTitles forKey:kIASKShortTitles];
-	}
-    
+        [multipleValuesDict setObject:shortTitles forKey:kIASKShortTitles];
+    }
+
+    if (iconNames.count) {
+        [multipleValuesDict setObject:iconNames forKey:kIASKIconNames];
+    }
+
     [self setMultipleValuesDict:multipleValuesDict];
 }
 
 - (void)sortIfNeeded {
     if (self.displaySortedByTitle) {
-		NSArray *values = self.multipleValues ?: [_specifierDict objectForKey:kIASKValues];
-		NSArray *titles = self.multipleTitles ?: [_specifierDict objectForKey:kIASKTitles];
-		NSArray *shortTitles = self.multipleShortTitles ?: [_specifierDict objectForKey:kIASKShortTitles];
+        NSArray *values = self.multipleValues ?: [_specifierDict objectForKey:kIASKValues];
+        NSArray *titles = self.multipleTitles ?: [_specifierDict objectForKey:kIASKTitles];
+        NSArray *shortTitles = self.multipleShortTitles ?: [_specifierDict objectForKey:kIASKShortTitles];
+        NSArray *iconNames = self.multipleIconNames ?: [_specifierDict objectForKey:kIASKIconNames];
 
         NSAssert(values.count == titles.count, @"Malformed multi-value specifier found in settings bundle. Number of values and titles differ.");
         NSAssert(shortTitles == nil || shortTitles.count == values.count, @"Malformed multi-value specifier found in settings bundle. Number of short titles and values differ.");
+        NSAssert(iconNames == nil || iconNames.count == values.count, @"Malformed multi-value specifier found in settings bundle. Number of icon names and values differ.");
 
         NSMutableDictionary *multipleValuesDict = [NSMutableDictionary new];
 
@@ -96,7 +104,9 @@
         static NSString *const titleKey = @"title";
         static NSString *const shortTitleKey = @"shortTitle";
         static NSString *const localizedTitleKey = @"localizedTitle";
+        static NSString *const iconNamesKey = @"iconNamesKey";
         static NSString *const valueKey = @"value";
+
         IASKSettingsReader *strongSettingsReader = self.settingsReader;
         [titles enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
             NSString *localizedTitle = [strongSettingsReader titleForId:obj];
@@ -104,6 +114,7 @@
                                                   valueKey : values[idx],
                                                   localizedTitleKey : localizedTitle,
                                                   shortTitleKey : (shortTitles[idx] ?: [NSNull null]),
+                                                  iconNamesKey : (iconNames[idx] ?: [NSNull null]),
                                                   }];
         }];
         
@@ -121,6 +132,7 @@
         NSMutableArray *sortedTitles = [NSMutableArray arrayWithCapacity:sortedTemporaryMappings.count];
         NSMutableArray *sortedShortTitles = [NSMutableArray arrayWithCapacity:sortedTemporaryMappings.count];
         NSMutableArray *sortedValues = [NSMutableArray arrayWithCapacity:sortedTemporaryMappings.count];
+        NSMutableArray *sortedIconNames = [NSMutableArray arrayWithCapacity:sortedTemporaryMappings.count];
 
         [sortedTemporaryMappings enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
             NSDictionary *mapping = obj;
@@ -129,10 +141,14 @@
             if (mapping[shortTitleKey] != [NSNull null]) {
                 sortedShortTitles[idx] = mapping[shortTitleKey];
             }
+            if (mapping[iconNamesKey] != [NSNull null]) {
+                sortedIconNames[idx] = mapping[iconNamesKey];
+            }
         }];
         titles = [sortedTitles copy];
         values = [sortedValues copy];
         shortTitles = [sortedShortTitles copy];
+        iconNames = [iconNames copy];
         
         if (values) {
             [multipleValuesDict setObject:values forKey:kIASKValues];
@@ -145,7 +161,11 @@
         if (shortTitles.count) {
             [multipleValuesDict setObject:shortTitles forKey:kIASKShortTitles];
         }
-        
+
+        if (iconNames.count) {
+            [multipleValuesDict setObject:iconNames forKey:kIASKIconNames];
+        }
+
         [self setMultipleValuesDict:multipleValuesDict];
     }
 }
@@ -255,6 +275,10 @@
 
 - (NSArray*)multipleTitles {
     return [_multipleValuesDict objectForKey:kIASKTitles];
+}
+
+- (NSArray *)multipleIconNames {
+    return [_multipleValuesDict objectForKey:kIASKIconNames];
 }
 
 - (NSArray*)multipleShortTitles {

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ MultiValue lists (`PSMultiValueSpecifier`) can fetch their values and titles dyn
 The sample app returns a list of all country codes as values and the localized country names as titles.
 
 MultiValue lists can be sorted alphabetically by adding a `true` Boolean `DisplaySortedByTitle` key in the Plist.
-
+MultiValue list entries can be given an image. Specify images via the `IconNames` attribute (next to Values/Titles/ShortTitles etc.).
 
 Settings Storage
 ----------------


### PR DESCRIPTION
allow specifying icons for multi values:
1) specified via IconNames array (anlog to Titles, Values, IconName)
2) currently read via [UIImage imageNamed:]