### PR TITLE
Improved UX for regex validation failures.

### DIFF
--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.h
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.h
@@ -20,6 +20,7 @@
 #import <InAppSettingsKit/IASKSettingsStore.h>
 #import <InAppSettingsKit/IASKViewController.h>
 #import <InAppSettingsKit/IASKSpecifier.h>
+#import <InAppSettingsKit/IASKTextField.h>
 
 @class IASKSettingsReader;
 @class IASKAppSettingsViewController;
@@ -78,6 +79,16 @@ shouldPresentMailComposeViewController:(MFMailComposeViewController*)mailCompose
 - (void)settingsViewController:(IASKAppSettingsViewController*)sender buttonTappedForKey:(NSString*)key __attribute__((deprecated)); // use the method below with specifier instead
 - (void)settingsViewController:(IASKAppSettingsViewController*)sender buttonTappedForSpecifier:(IASKSpecifier*)specifier;
 - (void)settingsViewController:(IASKAppSettingsViewController*)sender tableView:(UITableView *)tableView didSelectCustomViewSpecifier:(IASKSpecifier*)specifier;
+
+#pragma mark - regex validation failure handling
+- (BOOL)settingsViewController:(IASKAppSettingsViewController*)sender
+ validationFailureForSpecifier:(IASKSpecifier*)specifier
+                     textField:(IASKTextField *)field
+                     prevValue:(NSString*)prevValue;
+
+- (void)settingsViewController:(IASKAppSettingsViewController*)sender
+ validationSuccessForSpecifier:(IASKSpecifier*)specifier
+                     textField:(IASKTextField *)field;
 @end
 
 

--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -986,6 +986,7 @@ CGRect IASKCGRectSwap(CGRect rect);
             textValue = [NSString stringWithFormat:@"%@", textValue];
         }
         text.text = textValue;
+		[text shake];
     }
 }
 

--- a/InAppSettingsKit/Views/IASKTextField.h
+++ b/InAppSettingsKit/Views/IASKTextField.h
@@ -22,4 +22,6 @@
 @property (nonatomic, copy) NSString *key;
 @property (nonatomic, copy) NSRegularExpression *regex;
 
+- (void)shake;
+
 @end

--- a/InAppSettingsKit/Views/IASKTextField.m
+++ b/InAppSettingsKit/Views/IASKTextField.m
@@ -19,4 +19,14 @@
 
 @implementation IASKTextField
 
+- (void)shake {
+	CABasicAnimation *animation = [CABasicAnimation animationWithKeyPath:@"position"];
+	animation.duration     = 0.1;
+	animation.repeatCount  = 2;
+	animation.autoreverses = true;
+	animation.fromValue    = [NSValue valueWithCGPoint: CGPointMake(self.center.x - 10, self.center.y)];
+	animation.toValue      = [NSValue valueWithCGPoint: CGPointMake(self.center.x + 10, self.center.y)];
+	[self.layer addAnimation:animation forKey:@"position"];
+}
+
 @end

--- a/InAppSettingsKitSampleApp/Classes/MainViewController.m
+++ b/InAppSettingsKitSampleApp/Classes/MainViewController.m
@@ -118,6 +118,25 @@
 	// your code here to reconfigure the app for changed settings
 }
 
+// optional delegate methods for handling regex validation
+- (BOOL)settingsViewController:(IASKAppSettingsViewController *)sender
+ validationFailureForSpecifier:(IASKSpecifier *)specifier
+					 textField:(IASKTextField *)field
+					 prevValue:(NSString *)prevValue {
+	BOOL defaultBehaviour = YES;
+	if ([field.key isEqual: @"RegexValidation2"]) {
+		defaultBehaviour = NO;
+		field.textColor  = UIColor.redColor;
+	}
+	return defaultBehaviour;
+}
+
+- (void)settingsViewController:(IASKAppSettingsViewController *)sender
+ validationSuccessForSpecifier:(IASKSpecifier *)specifier
+					 textField:(IASKTextField *)field {
+	field.textColor = nil;
+}
+
 // optional delegate method for handling mail sending result
 - (BOOL)settingsViewController:(id<IASKViewController>)settingsViewController
 shouldPresentMailComposeViewController:(MFMailComposeViewController*)mailComposeViewController

--- a/InAppSettingsKitSampleApp/Settings.bundle/Root.inApp.plist
+++ b/InAppSettingsKitSampleApp/Settings.bundle/Root.inApp.plist
@@ -312,7 +312,22 @@
 			<key>Title</key>
 			<string>Regex validation</string>
 			<key>Type</key>
-			<string>PSTextFieldSpecifier</string><key>DefaultValue</key>
+			<string>PSTextFieldSpecifier</string>
+			<key>DefaultValue</key>
+			<string>test@example.com</string>
+			<key>IASKTextAlignment</key>
+			<string>IASKUITextAlignmentRight</string>
+			<key>IASKRegex</key>
+			<string>.+\@.+</string>
+		</dict>
+		<dict>
+			<key>Key</key>
+			<string>RegexValidation2</string>
+			<key>Title</key>
+			<string>Regex validation 2</string>
+			<key>Type</key>
+			<string>PSTextFieldSpecifier</string>
+			<key>DefaultValue</key>
 			<string>test@example.com</string>
 			<key>IASKTextAlignment</key>
 			<string>IASKUITextAlignmentRight</string>

--- a/InAppSettingsKitSampleApp/Settings.bundle/Root~ipad.inApp.plist
+++ b/InAppSettingsKitSampleApp/Settings.bundle/Root~ipad.inApp.plist
@@ -324,7 +324,22 @@
 			<key>Title</key>
 			<string>Regex validation</string>
 			<key>Type</key>
-			<string>PSTextFieldSpecifier</string><key>DefaultValue</key>
+			<string>PSTextFieldSpecifier</string>
+			<key>DefaultValue</key>
+			<string>test@example.com</string>
+			<key>IASKTextAlignment</key>
+			<string>IASKUITextAlignmentRight</string>
+			<key>IASKRegex</key>
+			<string>.+\@.+</string>
+		</dict>
+		<dict>
+			<key>Key</key>
+			<string>RegexValidation2</string>
+			<key>Title</key>
+			<string>Regex validation 2</string>
+			<key>Type</key>
+			<string>PSTextFieldSpecifier</string>
+			<key>DefaultValue</key>
 			<string>test@example.com</string>
 			<key>IASKTextAlignment</key>
 			<string>IASKUITextAlignmentRight</string>

--- a/InAppSettingsKitSampleApp/Settings.bundle/Root~iphone.inApp.plist
+++ b/InAppSettingsKitSampleApp/Settings.bundle/Root~iphone.inApp.plist
@@ -324,7 +324,22 @@
 			<key>Title</key>
 			<string>Regex validation</string>
 			<key>Type</key>
-			<string>PSTextFieldSpecifier</string><key>DefaultValue</key>
+			<string>PSTextFieldSpecifier</string>
+			<key>DefaultValue</key>
+			<string>test@example.com</string>
+			<key>IASKTextAlignment</key>
+			<string>IASKUITextAlignmentRight</string>
+			<key>IASKRegex</key>
+			<string>.+\@.+</string>
+		</dict>
+		<dict>
+			<key>Key</key>
+			<string>RegexValidation2</string>
+			<key>Title</key>
+			<string>Regex validation 2</string>
+			<key>Type</key>
+			<string>PSTextFieldSpecifier</string>
+			<key>DefaultValue</key>
 			<string>test@example.com</string>
 			<key>IASKTextAlignment</key>
 			<string>IASKUITextAlignmentRight</string>

--- a/README.md
+++ b/README.md
@@ -246,6 +246,10 @@ Regular expression validation
 -----------------------------
 The `IASKRegex` key can be used to specify a regular expression for validating text entered into TextField. For example checking the text entered is a valid number (only one decimal point, if a minus sign is present it must be the first charecter, etc). When this key is used the settings store is only update when editting of the field finishes. This enables easier editing as the field doesn't have to be valid after every charecter change.
 
+The following optional delegate methods can be used to customise the behaviour on a validation failure, and subsequent validation sucess. For example the text field could be set to red to indicate the value isn't valid. The delegate can prevent the default validation failure behaviour by returning `FALSE` from the `validationFailureForSpecifier` method.
+- `(BOOL)settingsViewController:(IASKAppSettingsViewController*)sender validationFailureForSpecifier:(IASKSpecifier*)specifier textField:(IASKTextField *)field prevValue:(NSString*)prevValue;`
+- `(void)settingsViewController:(IASKAppSettingsViewController*)sender validationSuccessForSpecifier:(IASKSpecifier*)specifier textField:(IASKTextField *)field;`
+
 
 Text alignment
 --------------


### PR DESCRIPTION
The default behaviour is the text field shakes on a validation failure and the original value is reverted. By using some optional delegate methods it's possible to customise the behaviour. An example of both are included in the sample app.