### PR TITLE
Updated travis to use new iPhone 11 Pro simulator device name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ os: osx
 osx_image: xcode11
 language: objective-c
 xcode_workspace: InAppSettingsKit.xcworkspace
-xcode_destination: platform=iOS Simulator,OS=13.0,name=iPhone Xs
+xcode_destination: platform=iOS Simulator,OS=13.0,name=iPhone 11 Pro
 matrix:
   include:
     - stage: Static Library & Tests
@@ -12,7 +12,7 @@ matrix:
         - xcodebuild -workspace InAppSettingsKit.xcworkspace -scheme InAppSettingsKitFramework build | xcpretty
     - stage: Sample App
       script:
-        - xcodebuild -workspace InAppSettingsKit.xcworkspace -scheme Sample\ App -destination platform\=iOS\ Simulator,OS\=13.0,name\=iPhone\ Xs build | xcpretty
+        - xcodebuild -workspace InAppSettingsKit.xcworkspace -scheme Sample\ App -destination platform\=iOS\ Simulator,OS\=13.0,name\=iPhone\ 11\ Pro build | xcpretty
     - stage: Carthage Setup
       script:
         - ./scripts/test-carthage.sh


### PR DESCRIPTION
Latest Xcode 11 has removed iPhone Xs target, replacing it with iPhone 11 Pro