### PR TITLE
Minor Appearance fixes

### DIFF
--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -803,6 +803,7 @@ CGRect IASKCGRectSwap(CGRect rect);
 		IASKSpecifier *childSpecifier = [[IASKSpecifier alloc] initWithSpecifier:specifier.specifierDict];
 		childSpecifier.settingsReader = self.settingsReader;
 		IASKSpecifierValuesViewController *targetViewController = [[IASKSpecifierValuesViewController alloc] initWithSpecifier:childSpecifier];
+        targetViewController.view.backgroundColor = self.view.backgroundColor;
 		targetViewController.settingsReader = self.settingsReader;
 		[self setMultiValuesFromDelegateIfNeeded:childSpecifier];
 
@@ -885,6 +886,7 @@ CGRect IASKCGRectSwap(CGRect rect);
         targetViewController.file = (id)specifier.file;
         targetViewController.hiddenKeys = self.hiddenKeys;
         targetViewController.title = specifier.title;
+		targetViewController.view.backgroundColor = self.view.backgroundColor;
         _currentChildViewController = targetViewController;
         
         _reloadDisabled = NO;

--- a/InAppSettingsKit/Controllers/IASKSpecifierValuesViewController.m
+++ b/InAppSettingsKit/Controllers/IASKSpecifierValuesViewController.m
@@ -104,7 +104,12 @@
     }
 
     [self.selection updateSelectionInCell:cell indexPath:indexPath];
-
+	UIColor *textColor = [UILabel appearanceWhenContainedIn:UITableViewCell.class, nil].textColor;
+	if (textColor == nil) {
+		textColor = [UILabel appearance].textColor;
+	}
+	cell.textLabel.textColor = textColor;
+    
     @try {
         [[cell textLabel] setText:[self.settingsReader titleForId:[titles objectAtIndex:indexPath.row]]];
         if ((NSInteger)iconNames.count > indexPath.row) {

--- a/InAppSettingsKitSampleApp/Launch.xib
+++ b/InAppSettingsKitSampleApp/Launch.xib
@@ -1,28 +1,40 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB">
-            <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <tabBar contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="miT-Ke-F3e">
-                    <rect key="frame" x="0.0" y="551" width="600" height="49"/>
-                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                <tabBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="miT-Ke-F3e">
+                    <rect key="frame" x="0.0" y="618" width="375" height="49"/>
+                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                     <items/>
                 </tabBar>
-                <navigationBar contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ycU-BO-9pq">
-                    <rect key="frame" x="0.0" y="0.0" width="600" height="44"/>
+                <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ycU-BO-9pq">
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                     <items>
                         <navigationItem id="naK-yG-ZYv"/>
                     </items>
                 </navigationBar>
             </subviews>
-            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstItem="ycU-BO-9pq" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="1uj-uE-rpw"/>
+                <constraint firstAttribute="trailing" secondItem="miT-Ke-F3e" secondAttribute="trailing" id="Szc-Fz-t1v"/>
+                <constraint firstItem="ycU-BO-9pq" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="Vt9-BT-WOa"/>
+                <constraint firstAttribute="trailing" secondItem="ycU-BO-9pq" secondAttribute="trailing" id="bOj-IK-MdD"/>
+                <constraint firstAttribute="bottom" secondItem="miT-Ke-F3e" secondAttribute="bottom" id="f9h-jB-E8D"/>
+                <constraint firstItem="miT-Ke-F3e" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="qsB-nZ-VIS"/>
+            </constraints>
+            <point key="canvasLocation" x="34" y="54"/>
         </view>
     </objects>
 </document>


### PR DESCRIPTION
This PR fixes some minor appearance issues I came across:

- the fake tab bar in the examples Launch Screen isn't anchored to the screen's bottom
- When setting a background color on IASK's view, I would like to see that same bg color in multi-value selection views as well as in "regular" child panes
- In multi-value selections, text labels should use the colors specified using UILabel's appearance, as they do in the "main" table views.