### PR TITLE
Update IASKSpecifier.m

### DIFF
--- a/InAppSettingsKit/Models/IASKSpecifier.m
+++ b/InAppSettingsKit/Models/IASKSpecifier.m
@@ -523,7 +523,10 @@
 
 - (IASKSpecifier*)addSpecifier {
 	NSDictionary *specifierDictionary = [_specifierDict objectForKey:kIASKAddSpecifier];
-    IASKSpecifier *addSpecifier = [[IASKSpecifier alloc] initWithSpecifier:specifierDictionary];
+	if (specifierDictionary == nil) {
+		return nil;
+	}
+	IASKSpecifier *addSpecifier = [[IASKSpecifier alloc] initWithSpecifier:specifierDictionary];
 	addSpecifier.parentSpecifier = self;
 	addSpecifier.itemIndex = NSUIntegerMax;
 	BOOL validType = [@[kIASKPSChildPaneSpecifier, kIASKPSTextFieldSpecifier, kIASKPSMultiValueSpecifier, kIASKButtonSpecifier, kIASKCustomViewSpecifier] containsObject:addSpecifier.type];


### PR DESCRIPTION
Support non-existing add specifier for lists. 

Related Stack Overflow: https://stackoverflow.com/questions/64812361/how-can-i-reuse-a-plist-file-with-inappsettingskit

By allowing the `specifierDictionary` to be `null`, no `AddSpecifier` is required.
This can be used where there is a pre-defined list and the delete option not being true.

Tested/verified locally