### PR TITLE
switch Carthage test to use XCFrameworks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,6 @@ matrix:
         - xcodebuild -workspace InAppSettingsKit.xcworkspace -scheme Sample\ App -destination platform\=iOS\ Simulator,OS\=14.1,name\=iPhone\ 12 build | xcpretty
     - stage: Carthage Setup
       script:
+        - brew update
+        - (brew list carthage && brew upgrade carthage) || brew install carthage
         - ./scripts/test-carthage.sh

--- a/scripts/test-carthage.sh
+++ b/scripts/test-carthage.sh
@@ -25,12 +25,12 @@ echo "git \"$IASKSETTINGSKIT_DIR\" \"$IASKSETTINGSKIT_BRANCH\"" > CarthageTest/C
 
 pushd CarthageTest > /dev/null
 
-carthage bootstrap --configuration Debug --verbose
+carthage bootstrap --use-xcframeworks --configuration Debug --verbose
 EXIT_CODE=$?
 
 echo "Checking for build products..."
 
-if [ ! -d "Carthage/Build/iOS/InAppSettingsKit.framework" ]; then
+if [ ! -d "Carthage/Build/InAppSettingsKit.xcframework" ]; then
     echo "No iOS library built"
     EXIT_CODE=1
 else


### PR DESCRIPTION
we're building arm64 for the mac (simulator) now as well,
so we need XCFrameworks, given it's arm64 for iOS & Simulator.