### PR TITLE
allow use of `.insetGrouped` table view style

### DIFF
--- a/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -135,8 +135,8 @@ CGRect IASKCGRectSwap(CGRect rect);
 }
 
 - (id)initWithStyle:(UITableViewStyle)style {
-    if (style != UITableViewStyleGrouped) {
-        NSLog(@"WARNING: only UITableViewStyleGrouped style is supported by InAppSettingsKit.");
+    if (style == UITableViewStylePlain) {
+        NSLog(@"WARNING: only \"grouped\" table view styles are supported by InAppSettingsKit.");
     }
     if ((self = [super initWithStyle:style])) {
 		[self configure];
@@ -837,7 +837,7 @@ CGRect IASKCGRectSwap(CGRect rect);
     if ([specifier.type isEqualToString:kIASKPSMultiValueSpecifier]) {
 		IASKSpecifier *childSpecifier = [[IASKSpecifier alloc] initWithSpecifier:specifier.specifierDict];
 		childSpecifier.settingsReader = self.settingsReader;
-		IASKSpecifierValuesViewController *targetViewController = [[IASKSpecifierValuesViewController alloc] initWithSpecifier:childSpecifier];
+		IASKSpecifierValuesViewController *targetViewController = [[IASKSpecifierValuesViewController alloc] initWithSpecifier:childSpecifier style:self.tableView.style];
         targetViewController.view.backgroundColor = self.view.backgroundColor;
 		targetViewController.settingsReader = self.settingsReader;
 		[self setMultiValuesFromDelegateIfNeeded:childSpecifier];
@@ -913,8 +913,8 @@ CGRect IASKCGRectSwap(CGRect rect);
         }
         
         _reloadDisabled = YES; // Disable internal unnecessary reloads
-        
-        IASKAppSettingsViewController *targetViewController = [[[self class] alloc] init];
+        IASKAppSettingsViewController *targetViewController =
+            [((IASKAppSettingsViewController*)[[self class] alloc]) initWithStyle:self.tableView.style];
         targetViewController.showDoneButton = NO;
         targetViewController.showCreditsFooter = NO; // Does not reload the tableview (but next setters do it)
         targetViewController.delegate = self.delegate;

--- a/InAppSettingsKit/Controllers/IASKSpecifierValuesViewController.h
+++ b/InAppSettingsKit/Controllers/IASKSpecifierValuesViewController.h
@@ -23,5 +23,6 @@
 @interface IASKSpecifierValuesViewController : UITableViewController <IASKViewController>
 
 - (nonnull id)initWithSpecifier:(nonnull IASKSpecifier*)specifier;
+- (nonnull id)initWithSpecifier:(nonnull IASKSpecifier*)specifier style:(UITableViewStyle)style;
 
 @end

--- a/InAppSettingsKit/Controllers/IASKSpecifierValuesViewController.m
+++ b/InAppSettingsKit/Controllers/IASKSpecifierValuesViewController.m
@@ -41,6 +41,13 @@
 	return self;
 }
 
+- (id)initWithSpecifier:(IASKSpecifier*)specifier style:(UITableViewStyle)style {
+	if ((self = [super initWithStyle:style])) {
+		self.currentSpecifier = specifier;
+	};
+	return self;
+}
+
 - (void)setSettingsStore:(id <IASKSettingsStore>)settingsStore {
 	self.selection = [[IASKMultipleValueSelection alloc] initWithSettingsStore:settingsStore tableView:self.tableView specifier:self.currentSpecifier section:0];
 }


### PR DESCRIPTION
For pure in-app settings in apps targeting iOS 13 and later, I would like to use the `.insetGrouped` table view style, currently this only works on the "main" page of the settings (and is accompanied by a warning).

This PR changes the warning to only complain when `.plain` is used, as well as passing the style down to multi-values selections and child panes.