### PR TITLE
Remove debug log when using multi value delegate

### DIFF
--- a/Sources/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/Sources/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -1291,7 +1291,6 @@ static NSMutableDictionary *oldUserDefaults = nil;
 
 - (void)setMultiValuesFromDelegateIfNeeded:(IASKSpecifier *)specifier {
 	if (specifier.multipleValues.count == 0) {
-		NSLog(@"need to init from delegate");
 		if ([self.delegate respondsToSelector:@selector(settingsViewController:valuesForSpecifier:)] &&
 			[self.delegate respondsToSelector:@selector(settingsViewController:titlesForSpecifier:)])
 		{


### PR DESCRIPTION
This log is printed every time when showing or entering a multi-value option using the delegate methods, and doesn’t seem particularly helpful.