### PR TITLE
fix missing carthage headers

### DIFF
--- a/InAppSettingsKit.xcodeproj/project.pbxproj
+++ b/InAppSettingsKit.xcodeproj/project.pbxproj
@@ -9,28 +9,28 @@
 /* Begin PBXBuildFile section */
 		1AA1073290B7DC27EB0C6A70 /* IASKMultipleValueSelection.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AA10C9888067F44636DBF0D /* IASKMultipleValueSelection.m */; };
 		2B81DB922452F59F00714832 /* IASKSettingsStoreInMemory.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B81DB902452F59F00714832 /* IASKSettingsStoreInMemory.m */; };
-		9B98D2D126EFE26C0062D77E /* IASKEmbeddedDatePickerViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2BB26EFE26C0062D77E /* IASKEmbeddedDatePickerViewCell.h */; };
-		9B98D2D226EFE26C0062D77E /* IASKPSTextFieldSpecifierViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2BC26EFE26C0062D77E /* IASKPSTextFieldSpecifierViewCell.h */; };
-		9B98D2D326EFE26C0062D77E /* IASKMultipleValueSelection.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2BD26EFE26C0062D77E /* IASKMultipleValueSelection.h */; };
-		9B98D2D426EFE26C0062D77E /* IASKSwitch.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2BE26EFE26C0062D77E /* IASKSwitch.h */; };
-		9B98D2D526EFE26C0062D77E /* IASKColor.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2BF26EFE26C0062D77E /* IASKColor.h */; };
-		9B98D2D626EFE26C0062D77E /* IASKAppSettingsViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2C026EFE26C0062D77E /* IASKAppSettingsViewController.h */; };
-		9B98D2D726EFE26C0062D77E /* IASKSettingsStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2C126EFE26C0062D77E /* IASKSettingsStore.h */; };
-		9B98D2D826EFE26C0062D77E /* IASKSettingsStoreFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2C226EFE26C0062D77E /* IASKSettingsStoreFile.h */; };
-		9B98D2D926EFE26C0062D77E /* IASKSpecifierValuesViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2C326EFE26C0062D77E /* IASKSpecifierValuesViewController.h */; };
-		9B98D2DA26EFE26C0062D77E /* IASKSlider.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2C426EFE26C0062D77E /* IASKSlider.h */; };
-		9B98D2DB26EFE26C0062D77E /* IASKTextViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2C526EFE26C0062D77E /* IASKTextViewCell.h */; };
-		9B98D2DC26EFE26C0062D77E /* IASKTextField.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2C626EFE26C0062D77E /* IASKTextField.h */; };
-		9B98D2DD26EFE26C0062D77E /* IASKDatePicker.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2C726EFE26C0062D77E /* IASKDatePicker.h */; };
-		9B98D2DE26EFE26C0062D77E /* IASKTextView.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2C826EFE26C0062D77E /* IASKTextView.h */; };
-		9B98D2DF26EFE26C0062D77E /* IASKDatePickerViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2C926EFE26C0062D77E /* IASKDatePickerViewCell.h */; };
-		9B98D2E026EFE26C0062D77E /* IASKPSSliderSpecifierViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2CA26EFE26C0062D77E /* IASKPSSliderSpecifierViewCell.h */; };
-		9B98D2E126EFE26C0062D77E /* IASKSpecifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2CB26EFE26C0062D77E /* IASKSpecifier.h */; };
-		9B98D2E226EFE26C0062D77E /* IASKAppSettingsWebViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2CC26EFE26C0062D77E /* IASKAppSettingsWebViewController.h */; };
-		9B98D2E326EFE26C0062D77E /* IASKViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2CD26EFE26C0062D77E /* IASKViewController.h */; };
-		9B98D2E426EFE26C0062D77E /* IASKSettingsReader.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2CE26EFE26C0062D77E /* IASKSettingsReader.h */; };
-		9B98D2E526EFE26C0062D77E /* IASKSettingsStoreUserDefaults.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2CF26EFE26C0062D77E /* IASKSettingsStoreUserDefaults.h */; };
-		9B98D2E626EFE26C0062D77E /* IASKSettingsStoreInMemory.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2D026EFE26C0062D77E /* IASKSettingsStoreInMemory.h */; };
+		9B98D2D126EFE26C0062D77E /* IASKEmbeddedDatePickerViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2BB26EFE26C0062D77E /* IASKEmbeddedDatePickerViewCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9B98D2D226EFE26C0062D77E /* IASKPSTextFieldSpecifierViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2BC26EFE26C0062D77E /* IASKPSTextFieldSpecifierViewCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9B98D2D326EFE26C0062D77E /* IASKMultipleValueSelection.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2BD26EFE26C0062D77E /* IASKMultipleValueSelection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9B98D2D426EFE26C0062D77E /* IASKSwitch.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2BE26EFE26C0062D77E /* IASKSwitch.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9B98D2D526EFE26C0062D77E /* IASKColor.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2BF26EFE26C0062D77E /* IASKColor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9B98D2D626EFE26C0062D77E /* IASKAppSettingsViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2C026EFE26C0062D77E /* IASKAppSettingsViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9B98D2D726EFE26C0062D77E /* IASKSettingsStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2C126EFE26C0062D77E /* IASKSettingsStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9B98D2D826EFE26C0062D77E /* IASKSettingsStoreFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2C226EFE26C0062D77E /* IASKSettingsStoreFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9B98D2D926EFE26C0062D77E /* IASKSpecifierValuesViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2C326EFE26C0062D77E /* IASKSpecifierValuesViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9B98D2DA26EFE26C0062D77E /* IASKSlider.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2C426EFE26C0062D77E /* IASKSlider.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9B98D2DB26EFE26C0062D77E /* IASKTextViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2C526EFE26C0062D77E /* IASKTextViewCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9B98D2DC26EFE26C0062D77E /* IASKTextField.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2C626EFE26C0062D77E /* IASKTextField.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9B98D2DD26EFE26C0062D77E /* IASKDatePicker.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2C726EFE26C0062D77E /* IASKDatePicker.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9B98D2DE26EFE26C0062D77E /* IASKTextView.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2C826EFE26C0062D77E /* IASKTextView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9B98D2DF26EFE26C0062D77E /* IASKDatePickerViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2C926EFE26C0062D77E /* IASKDatePickerViewCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9B98D2E026EFE26C0062D77E /* IASKPSSliderSpecifierViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2CA26EFE26C0062D77E /* IASKPSSliderSpecifierViewCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9B98D2E126EFE26C0062D77E /* IASKSpecifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2CB26EFE26C0062D77E /* IASKSpecifier.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9B98D2E226EFE26C0062D77E /* IASKAppSettingsWebViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2CC26EFE26C0062D77E /* IASKAppSettingsWebViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9B98D2E326EFE26C0062D77E /* IASKViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2CD26EFE26C0062D77E /* IASKViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9B98D2E426EFE26C0062D77E /* IASKSettingsReader.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2CE26EFE26C0062D77E /* IASKSettingsReader.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9B98D2E526EFE26C0062D77E /* IASKSettingsStoreUserDefaults.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2CF26EFE26C0062D77E /* IASKSettingsStoreUserDefaults.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9B98D2E626EFE26C0062D77E /* IASKSettingsStoreInMemory.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2D026EFE26C0062D77E /* IASKSettingsStoreInMemory.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA028087246DFB0300681B8E /* IASKSettingsStoreInMemory.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B81DB902452F59F00714832 /* IASKSettingsStoreInMemory.m */; };
 		AA0A85EC1C89C9AB0036F778 /* IASKTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = AA5AB5271C88974100B20124 /* IASKTextView.m */; };
 		AA0A85EE1C89C9B70036F778 /* IASKTextViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = AA5AB5291C88974100B20124 /* IASKTextViewCell.m */; };
@@ -69,6 +69,28 @@
 		E42ADAAA168202D700295D85 /* libInAppSettingsKit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E42ADA8F168202D700295D85 /* libInAppSettingsKit.a */; };
 		E42ADAB0168202D700295D85 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = E42ADAAE168202D700295D85 /* InfoPlist.strings */; };
 		E42ADAB3168202D700295D85 /* IASSettingsStoreUserDefaultsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E42ADAB2168202D700295D85 /* IASSettingsStoreUserDefaultsTests.m */; };
+		E4E2E7B9270B565B003960CF /* IASKSettingsStoreFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2C226EFE26C0062D77E /* IASKSettingsStoreFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4E2E7BA270B565B003960CF /* IASKDatePickerViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2C926EFE26C0062D77E /* IASKDatePickerViewCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4E2E7BB270B565B003960CF /* IASKAppSettingsWebViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2CC26EFE26C0062D77E /* IASKAppSettingsWebViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4E2E7BC270B565B003960CF /* IASKMultipleValueSelection.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2BD26EFE26C0062D77E /* IASKMultipleValueSelection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4E2E7BD270B565B003960CF /* IASKColor.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2BF26EFE26C0062D77E /* IASKColor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4E2E7BE270B565B003960CF /* IASKTextViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2C526EFE26C0062D77E /* IASKTextViewCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4E2E7BF270B565B003960CF /* IASKSpecifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2CB26EFE26C0062D77E /* IASKSpecifier.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4E2E7C0270B565B003960CF /* IASKEmbeddedDatePickerViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2BB26EFE26C0062D77E /* IASKEmbeddedDatePickerViewCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4E2E7C1270B565B003960CF /* IASKAppSettingsViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2C026EFE26C0062D77E /* IASKAppSettingsViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4E2E7C2270B565B003960CF /* IASKSettingsReader.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2CE26EFE26C0062D77E /* IASKSettingsReader.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4E2E7C3270B565B003960CF /* IASKPSTextFieldSpecifierViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2BC26EFE26C0062D77E /* IASKPSTextFieldSpecifierViewCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4E2E7C4270B565B003960CF /* IASKSwitch.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2BE26EFE26C0062D77E /* IASKSwitch.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4E2E7C5270B565B003960CF /* IASKViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2CD26EFE26C0062D77E /* IASKViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4E2E7C6270B565B003960CF /* IASKSettingsStoreUserDefaults.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2CF26EFE26C0062D77E /* IASKSettingsStoreUserDefaults.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4E2E7C7270B565B003960CF /* IASKSettingsStoreInMemory.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2D026EFE26C0062D77E /* IASKSettingsStoreInMemory.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4E2E7C8270B565B003960CF /* IASKSlider.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2C426EFE26C0062D77E /* IASKSlider.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4E2E7C9270B565B003960CF /* IASKTextField.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2C626EFE26C0062D77E /* IASKTextField.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4E2E7CA270B565B003960CF /* IASKSettingsStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2C126EFE26C0062D77E /* IASKSettingsStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4E2E7CB270B565B003960CF /* IASKDatePicker.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2C726EFE26C0062D77E /* IASKDatePicker.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4E2E7CC270B565B003960CF /* IASKTextView.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2C826EFE26C0062D77E /* IASKTextView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4E2E7CD270B565B003960CF /* IASKSpecifierValuesViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2C326EFE26C0062D77E /* IASKSpecifierValuesViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E4E2E7CE270B565B003960CF /* IASKPSSliderSpecifierViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B98D2CA26EFE26C0062D77E /* IASKPSSliderSpecifierViewCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E4EDC59D16820D9500BD3CA9 /* IASKAppSettingsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E42ADAC31682036500295D85 /* IASKAppSettingsViewController.m */; };
 		E4EDC59E16820D9500BD3CA9 /* IASKSpecifierValuesViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E42ADAC51682036500295D85 /* IASKSpecifierValuesViewController.m */; };
 		E4EDC59F16820D9500BD3CA9 /* IASKAppSettingsWebViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E42ADAC71682036500295D85 /* IASKAppSettingsWebViewController.m */; };
@@ -480,7 +502,29 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E4E2E7BD270B565B003960CF /* IASKColor.h in Headers */,
+				E4E2E7C3270B565B003960CF /* IASKPSTextFieldSpecifierViewCell.h in Headers */,
 				DAC156261B54533D00655031 /* InAppSettingsKit.h in Headers */,
+				E4E2E7CE270B565B003960CF /* IASKPSSliderSpecifierViewCell.h in Headers */,
+				E4E2E7C1270B565B003960CF /* IASKAppSettingsViewController.h in Headers */,
+				E4E2E7BC270B565B003960CF /* IASKMultipleValueSelection.h in Headers */,
+				E4E2E7C0270B565B003960CF /* IASKEmbeddedDatePickerViewCell.h in Headers */,
+				E4E2E7C9270B565B003960CF /* IASKTextField.h in Headers */,
+				E4E2E7C8270B565B003960CF /* IASKSlider.h in Headers */,
+				E4E2E7CC270B565B003960CF /* IASKTextView.h in Headers */,
+				E4E2E7B9270B565B003960CF /* IASKSettingsStoreFile.h in Headers */,
+				E4E2E7C7270B565B003960CF /* IASKSettingsStoreInMemory.h in Headers */,
+				E4E2E7CB270B565B003960CF /* IASKDatePicker.h in Headers */,
+				E4E2E7BA270B565B003960CF /* IASKDatePickerViewCell.h in Headers */,
+				E4E2E7C2270B565B003960CF /* IASKSettingsReader.h in Headers */,
+				E4E2E7CD270B565B003960CF /* IASKSpecifierValuesViewController.h in Headers */,
+				E4E2E7BE270B565B003960CF /* IASKTextViewCell.h in Headers */,
+				E4E2E7C4270B565B003960CF /* IASKSwitch.h in Headers */,
+				E4E2E7CA270B565B003960CF /* IASKSettingsStore.h in Headers */,
+				E4E2E7BB270B565B003960CF /* IASKAppSettingsWebViewController.h in Headers */,
+				E4E2E7BF270B565B003960CF /* IASKSpecifier.h in Headers */,
+				E4E2E7C5270B565B003960CF /* IASKViewController.h in Headers */,
+				E4E2E7C6270B565B003960CF /* IASKSettingsStoreUserDefaults.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/scripts/test-carthage.sh
+++ b/scripts/test-carthage.sh
@@ -33,6 +33,9 @@ echo "Checking for build products..."
 if [ ! -d "Carthage/Build/InAppSettingsKit.xcframework" ]; then
     echo "No iOS library built"
     EXIT_CODE=1
+elif [ `find Carthage/Build/InAppSettingsKit.xcframework -name "*.h" | wc -l` -le 3 ]; then
+    echo "Not enough headers present - please make sure the xcodeproj is still correctly setup"
+    EXIT_CODE=2
 else
     echo "Found iOS framework"
 fi


### PR DESCRIPTION
We somehow dropped the public headers for the framework in the last update.
This fixes it and brings them back (and adds a silly little test to make sure it's not happening again) (fixes #463)

Thanks @prashant-bhargava-hs for finding it! 🙏 

