### PR TITLE
Support for building for visionOS

### DIFF
--- a/Sources/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/Sources/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -936,7 +936,9 @@ CGRect IASKCGRectSwap(CGRect rect);
 		NSURL *url = urlString ? [NSURL URLWithString:urlString] : nil;
 		if (url) {
 			IASK_IF_IOS11_OR_GREATER([UIApplication.sharedApplication openURL:url options:@{} completionHandler:nil];);
+#if !TARGET_OS_XR
 			IASK_IF_PRE_IOS11([UIApplication.sharedApplication openURL:url];);
+#endif
 		}
 	} else if ([specifier.type isEqualToString:kIASKButtonSpecifier]) {
         if ([self.delegate respondsToSelector:@selector(settingsViewController:buttonTappedForSpecifier:)]) {
@@ -977,11 +979,11 @@ CGRect IASKCGRectSwap(CGRect rect);
 		if ([MFMailComposeViewController canSendMail]) {
 			mailViewController.mailComposeDelegate = self;
             _currentChildViewController = mailViewController;
-#if !TARGET_OS_MACCATALYST
+#if !TARGET_OS_MACCATALYST && !TARGET_OS_XR
             UIStatusBarStyle savedStatusBarStyle = [UIApplication sharedApplication].statusBarStyle;
 #endif
             [self presentViewController:mailViewController animated:YES completion:^{
-#if !TARGET_OS_MACCATALYST
+#if !TARGET_OS_MACCATALYST && !TARGET_OS_XR
 			    [UIApplication sharedApplication].statusBarStyle = savedStatusBarStyle;
 #endif
             }];

--- a/Sources/InAppSettingsKit/Controllers/IASKAppSettingsWebViewController.m
+++ b/Sources/InAppSettingsKit/Controllers/IASKAppSettingsWebViewController.m
@@ -54,7 +54,7 @@
 	[super viewWillAppear:animated];
 	
 	UIActivityIndicatorView *activityIndicatorView = [[UIActivityIndicatorView alloc] initWithFrame:CGRectMake(0, 0, 40, 20)];
-#if TARGET_OS_MACCATALYST
+#if TARGET_OS_MACCATALYST || TARGET_OS_XR
 	activityIndicatorView.activityIndicatorViewStyle = UIActivityIndicatorViewStyleMedium;
 #else
 	activityIndicatorView.activityIndicatorViewStyle = UIActivityIndicatorViewStyleWhite;
@@ -89,7 +89,9 @@
 	}
 
 	IASK_IF_IOS11_OR_GREATER([UIApplication.sharedApplication openURL:newURL options:@{} completionHandler:nil];);
+#if !TARGET_OS_XR
 	IASK_IF_PRE_IOS11([UIApplication.sharedApplication openURL:newURL];);
+#endif
 	decisionHandler(WKNavigationActionPolicyCancel);
 }
 
@@ -153,11 +155,11 @@
 	mailViewController.navigationBar.barStyle = self.navigationController.navigationBar.barStyle;
 	mailViewController.navigationBar.tintColor = self.navigationController.navigationBar.tintColor;
 	mailViewController.navigationBar.titleTextAttributes =  self.navigationController.navigationBar.titleTextAttributes;
-#if !TARGET_OS_MACCATALYST
+#if !TARGET_OS_MACCATALYST && !TARGET_OS_XR
 	UIStatusBarStyle savedStatusBarStyle = [UIApplication sharedApplication].statusBarStyle;
 #endif
 	[self presentViewController:mailViewController animated:YES completion:^{
-#if !TARGET_OS_MACCATALYST
+#if !TARGET_OS_MACCATALYST && !TARGET_OS_XR
 		[UIApplication sharedApplication].statusBarStyle = savedStatusBarStyle;
 #endif
 	}];


### PR DESCRIPTION
Excludes APIs unavailable when building for visionOS (everything deprecated before iOS 14).

