### PR TITLE
Add `bundle` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,54 @@ In order to start using IASK add `Settings.bundle` to your project (`File` -> `A
 To display InAppSettingsKit, instantiate `IASKAppSettingsViewController` and push it onto the navigation stack or embed it as the root view controller of a navigation controller.
 
 **In code, using Swift:**
+
 ```swift
 let appSettingsViewController = IASKAppSettingsViewController()
 navigationController.pushViewController(appSettingsViewController, animated: true)
 ```
 
+**In code, using Swift as part of a swift package:**
+
+In a modularized app, you might want to move all settings-related code into a separate package, and only reference the InAppSettingsKit dependency there. Your `Package.swift` would look like this:
+
+```swift
+let package = Package(
+    name: "SettingsPackage",
+    platforms: [.iOS(.v17)],
+    dependencies: [
+        .package(url: "https://github.com/futuretap/inappsettingskit", from: "3.4.0")
+    ],
+    .target(
+        name: "SettingsPackage",
+        dependencies: [
+            .product(name: "InAppSettingsKit", package: "inappsettingskit"),
+        ],
+        resources: [
+            .copy("InAppSettings.bundle")
+        ]
+    )
+)
+```
+
+(Note that the `InAppSettings.bundle` directory is also part of the package, and does not belong to the main app anymore.)
+
+Creating an `IASKAppSettingsViewController` now requires setting its `bundle` property to the package's bundle:
+
+```swift
+struct InAppSettingsView: UIViewControllerRepresentable {
+    func makeUIViewController(context: Context) -> some UIViewController {
+        let iask = IASKAppSettingsViewController(style: .insetGrouped)
+        iask.bundle = Bundle.module // IMPORTANT
+        return iask
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) { }
+}
+
+```
+
 **In code, using Objective-C:**
+
 ```objc
 IASKAppSettingsViewController *appSettingsViewController = [[IASKAppSettingsViewController alloc] init];
 [self.navigationController pushViewController:appSettingsViewController animated:YES];

--- a/Sources/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/Sources/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -70,7 +70,8 @@ CGRect IASKCGRectSwap(CGRect rect);
 #pragma mark accessors
 - (IASKSettingsReader*)settingsReader {
 	if (!_settingsReader) {
-		_settingsReader = [[IASKSettingsReader alloc] initWithFile:self.file];
+		NSBundle* bundle = _bundle == nil ? NSBundle.mainBundle : _bundle;
+		_settingsReader = [[IASKSettingsReader alloc] initWithFile:self.file bundle:bundle];
 		if (self.neverShowPrivacySettings) {
 			_settingsReader.showPrivacySettings = NO;
 		}

--- a/Sources/InAppSettingsKit/Models/IASKSettingsReader.m
+++ b/Sources/InAppSettingsKit/Models/IASKSettingsReader.m
@@ -332,7 +332,7 @@ NSString * const IASKSettingChangedNotification = @"IASKAppSettingChangedNotific
 				[dictionary setObject:(id)specifier.defaultValue forKey:(id)specifier.key];
 			}
 			if ([specifier.type isEqualToString:kIASKPSChildPaneSpecifier] && specifier.file) {
-				IASKSettingsReader *childReader = [[IASKSettingsReader alloc] initWithFile:(id)specifier.file];
+				IASKSettingsReader *childReader = [[IASKSettingsReader alloc] initWithFile:(id)specifier.file bundle:_applicationBundle];
 				childReader.settingsStore = self.settingsStore;
 				[childReader gatherDefaultsInDictionary:dictionary limitedToEditableFields:limitedToEditableFields apply:apply];
 			}

--- a/Sources/InAppSettingsKit/include/IASKAppSettingsViewController.h
+++ b/Sources/InAppSettingsKit/include/IASKAppSettingsViewController.h
@@ -254,6 +254,9 @@ typedef NS_ENUM(NSUInteger, IASKValidationResult) {
 /// Sets the same parameter on the tableView of the root and all child view controllers
 @property (nonatomic) IBInspectable BOOL cellLayoutMarginsFollowReadableWidth;
 
+/// The bundle to read the settings plist files from. Defaults to `NSBundle.mainBundle`.
+@property (nonatomic) NSBundle* bundle;
+
 /// Synchronizes the settings store, e.g. calls `-[NSUserDefaults synchronize]` in case of the default store.
 - (void)synchronizeSettings;
 


### PR DESCRIPTION
... to specify where `IASKSettingsReader` should read the plist files from.

This allows for `InAppSettings.bundle` to be part of the swift package instead of the main app, and the code in a swift package to use IASK like so:

```
struct InAppSettingsView: UIViewControllerRepresentable {
    func makeUIViewController(context: Context) -> some UIViewController {
        let iask = IASKAppSettingsViewController(style: .insetGrouped)
        iask.bundle = Bundle.module // added by this PR
        return iask
    }

    func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {
        // nop
    }
}
```

Fixes #486 