### PR TITLE
fix bundle for child panes

### DIFF
--- a/Sources/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
+++ b/Sources/InAppSettingsKit/Controllers/IASKAppSettingsViewController.m
@@ -918,6 +918,7 @@ CGRect IASKCGRectSwap(CGRect rect);
             [((IASKAppSettingsViewController*)[[self class] alloc]) initWithStyle:self.tableView.style];
         targetViewController.showDoneButton = NO;
         targetViewController.showCreditsFooter = NO; // Does not reload the tableview (but next setters do it)
+        targetViewController.bundle = self.bundle;
         targetViewController.delegate = self.delegate;
         targetViewController.file = (id)specifier.file;
         targetViewController.hiddenKeys = self.hiddenKeys;


### PR DESCRIPTION
Sorry, I missed one use case in #487: showing child panes from another plist file in the same packaged bundle. Fortunately, the fix is trivial.