### PR TITLE
Always allow Navigation Action for http/https URL scheme to prevent u…

### DIFF
--- a/Sources/InAppSettingsKit/Controllers/IASKAppSettingsWebViewController.m
+++ b/Sources/InAppSettingsKit/Controllers/IASKAppSettingsWebViewController.m
@@ -326,19 +326,20 @@
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler NS_EXTENSION_UNAVAILABLE("Uses APIs (i.e UIApplication.sharedApplication) not available for use in App Extensions.") {
     NSURL* newURL = navigationAction.request.URL;
     
-    // intercept mailto URL and send it to an in-app Mail compose view instead
-    if ([[newURL scheme] isEqualToString:@"mailto"]) {
+    // Intercept mailto URL scheme and send it to an in-app Mail compose view instead:
+    if ([newURL.scheme isEqualToString:@"mailto"]) {
         [self handleMailto:newURL];
         decisionHandler(WKNavigationActionPolicyCancel);
         return;
     }
     
-    // open inline if host is the same, otherwise, pass to the system
-    if (![newURL host] || ![self.url host] || [[newURL host] isEqualToString:(NSString *)[self.url host]]) {
+    // Allow loading of any http(s) requests:
+    if ([newURL.scheme isEqualToString:@"http"] || [newURL.scheme isEqualToString:@"https"]) {
         decisionHandler(WKNavigationActionPolicyAllow);
         return;
     }
     
+    // For any other URL scheme, let the system find an appropriate app to open the URL:
     [UIApplication.sharedApplication openURL:newURL
                                      options:@{}
                            completionHandler:nil];


### PR DESCRIPTION
…nexpected opening of Safari

See: https://github.com/futuretap/InAppSettingsKit/issues/512

I've used `isEqualToString:` twice for explicitly "http" and "https", instead of `hasPrefix:@"http"`to not catch any custom URL scheme like "httpappleprivate".

This solution has been validated with the test URL from the original issue report https://github.com/futuretap/InAppSettingsKit/issues/512#issuecomment-2440856071 and it now passes validation ✅