### PR TITLE
Fix visionOS build error in IASKAppSettingsWebViewController

### DIFF
--- a/Sources/InAppSettingsKit/Controllers/IASKAppSettingsWebViewController.m
+++ b/Sources/InAppSettingsKit/Controllers/IASKAppSettingsWebViewController.m
@@ -152,7 +152,9 @@
 		UIBarButtonItem *activityBarButtonItem = [[UIBarButtonItem alloc] initWithCustomView:self.activityIndicatorView];
 		IASK_IF_IOS26_OR_GREATER
 		(
+#if !TARGET_OS_VISION
 		 activityBarButtonItem.hidesSharedBackground = YES;
+#endif
 		 [barButtons addObject:UIBarButtonItem.fixedSpaceItem];
 		 )
 		[barButtons addObject:activityBarButtonItem];

--- a/Sources/InAppSettingsKit/include/IASKSettingsReader.h
+++ b/Sources/InAppSettingsKit/include/IASKSettingsReader.h
@@ -195,7 +195,7 @@ extern NSString * const IASKSettingChangedNotification;
 
 #ifdef __IPHONE_26_0
 #define IASK_IF_IOS26_OR_GREATER(...) \
-if (@available(iOS 26.0, *)) \
+if (@available(iOS 26.0, visionOS 26.0, *)) \
 { \
 __VA_ARGS__ \
 }


### PR DESCRIPTION
This PR fixes a build error on visionOS, where the `hidesSharedBackground` property of `UIBarButtonItem` is marked unavailable.

Additionally, it fixes an availability warning (for `UIBarButtonItem.fixedSpaceItem`) on the following line.